### PR TITLE
Fix #33: Refactor denoise

### DIFF
--- a/scripts/denoise/noise_train.py
+++ b/scripts/denoise/noise_train.py
@@ -114,6 +114,7 @@ def plot_noise_distribution_check(xs, ys, config_noise):
     fig.tight_layout(rect=(0.0, 0.0, 1.0, 0.97))
     return fig, ax
 
+
 cases = [
     {
         "name": "lti_denoise_wf",

--- a/scripts/linear_time_invariant/lti_nm.py
+++ b/scripts/linear_time_invariant/lti_nm.py
@@ -66,8 +66,6 @@ if ifprd:
             _pred = prd_func(xs, ts, u=us)
         res.append(_pred)
 
-    plot_multi_trajs(
-        np.array(res), ts[0], "LTI", us=us, labels=["Truth"] + labels, ifclose=False
-    )
+    plot_multi_trajs(np.array(res), ts[0], "LTI", us=us, labels=["Truth"] + labels, ifclose=False)
 
 plt.show()

--- a/src/dymad/numerics/__init__.py
+++ b/src/dymad/numerics/__init__.py
@@ -1,4 +1,5 @@
 from dymad.numerics.complex import complex_grid, complex_map, complex_plot, disc2cont
+from dymad.numerics.denoising import denoise, denoising_metrics
 from dymad.numerics.dm import DM, DMF, VBDM
 from dymad.numerics.gradients import central_diff, complex_step, torch_jacobian
 from dymad.numerics.linalg import (
@@ -38,6 +39,8 @@ __all__ = [
     "complex_step",
     "DimensionEstimator",
     "disc2cont",
+    "denoise",
+    "denoising_metrics",
     "DM",
     "DMF",
     "eig_low_rank",

--- a/src/dymad/numerics/denoising.py
+++ b/src/dymad/numerics/denoising.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias, overload
+
+import numpy as np
+import torch
+from scipy.signal import savgol_filter
+
+ArrayLike: TypeAlias = np.ndarray | torch.Tensor
+DenoiseMethod = Literal["savgol"]
+
+
+def _denoise_savgol(data: ArrayLike, *, axis: int, **kwargs) -> ArrayLike:
+    smoothed = savgol_filter(_to_numpy(data), axis=axis, **kwargs)
+    if isinstance(data, torch.Tensor):
+        return torch.as_tensor(smoothed, device=data.device, dtype=data.dtype)
+    return np.asarray(smoothed, dtype=data.dtype)
+
+
+def _to_numpy(data: ArrayLike) -> np.ndarray:
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().numpy()
+    return np.asarray(data)
+
+
+@overload
+def denoise(data: np.ndarray, *, method: str = "savgol", axis: int = 0, **kwargs) -> np.ndarray: ...
+
+
+@overload
+def denoise(
+    data: torch.Tensor, *, method: str = "savgol", axis: int = 0, **kwargs
+) -> torch.Tensor: ...
+
+
+def denoise(data: ArrayLike, *, method: str = "savgol", axis: int = 0, **kwargs) -> ArrayLike:
+    """Apply a model-independent denoising method while preserving the input array type."""
+    if method == "savgol":
+        return _denoise_savgol(data, axis=axis, **kwargs)
+    raise ValueError(f"Unsupported denoising method '{method}'.")
+
+
+def denoising_metrics(
+    *,
+    original: Sequence[ArrayLike],
+    denoised: Sequence[ArrayLike],
+) -> dict[str, float]:
+    """Aggregate denoising deltas and roughness statistics across one or more signals."""
+    if len(original) != len(denoised):
+        raise ValueError("Denoising metrics require matching dataset lengths.")
+
+    sum_sq_delta = 0.0
+    sum_abs_delta = 0.0
+    max_abs_delta = 0.0
+    sum_sq_signal = 0.0
+    n_elements = 0
+    sum_sq_diff_before = 0.0
+    sum_sq_diff_after = 0.0
+    n_diff_elements = 0
+
+    for before_signal, after_signal in zip(original, denoised, strict=False):
+        before = _to_numpy(before_signal)
+        after = _to_numpy(after_signal)
+        if before.shape != after.shape:
+            raise ValueError("Denoising metrics require matching signal shapes.")
+
+        delta = after - before
+        sum_sq_delta += float(np.square(delta).sum())
+        sum_abs_delta += float(np.abs(delta).sum())
+        max_abs_delta = max(max_abs_delta, float(np.abs(delta).max(initial=0.0)))
+        sum_sq_signal += float(np.square(before).sum())
+        n_elements += int(delta.size)
+
+        if before.shape[0] > 1:
+            diff_before = np.diff(before, axis=0)
+            diff_after = np.diff(after, axis=0)
+            sum_sq_diff_before += float(np.square(diff_before).sum())
+            sum_sq_diff_after += float(np.square(diff_after).sum())
+            n_diff_elements += int(diff_before.size)
+
+    delta_rmse = float(np.sqrt(sum_sq_delta / n_elements)) if n_elements > 0 else 0.0
+    signal_rms = float(np.sqrt(sum_sq_signal / n_elements)) if n_elements > 0 else 0.0
+    roughness_before = sum_sq_diff_before / n_diff_elements if n_diff_elements > 0 else 0.0
+    roughness_after = sum_sq_diff_after / n_diff_elements if n_diff_elements > 0 else 0.0
+    if roughness_before > 0.0:
+        roughness_ratio = roughness_after / roughness_before
+    elif roughness_after == 0.0:
+        roughness_ratio = 1.0
+    else:
+        roughness_ratio = float("inf")
+
+    return {
+        "delta_rmse": delta_rmse,
+        "delta_mae": sum_abs_delta / n_elements if n_elements > 0 else 0.0,
+        "delta_max_abs": max_abs_delta,
+        "delta_rel_rmse": (delta_rmse / signal_rms) if signal_rms > 0.0 else 0.0,
+        "roughness_before": roughness_before,
+        "roughness_after": roughness_after,
+        "roughness_delta": roughness_after - roughness_before,
+        "roughness_ratio": roughness_ratio,
+    }

--- a/src/dymad/training/driver.py
+++ b/src/dymad/training/driver.py
@@ -233,7 +233,9 @@ class DriverBase:
         max_iterations = search.get("max_iterations")
         if max_iterations is not None:
             if not isinstance(max_iterations, int) or max_iterations <= 0:
-                raise TypeError("cv.search.max_iterations must be a positive integer when provided.")
+                raise TypeError(
+                    "cv.search.max_iterations must be a positive integer when provided."
+                )
         self.cv_search_max_iterations = max_iterations
 
         reflection = search.get("reflection", 1.0)
@@ -657,7 +659,9 @@ class DriverBase:
             try:
                 current_value = get_by_dotted_key(self.base_config, key)
             except (KeyError, IndexError, TypeError, ValueError) as exc:
-                raise TypeError(f"cv.search.bounds[{key!r}] does not resolve in the config.") from exc
+                raise TypeError(
+                    f"cv.search.bounds[{key!r}] does not resolve in the config."
+                ) from exc
             if isinstance(current_value, bool):
                 raise TypeError(
                     f"cv.search.bounds[{key!r}] must target an integer or floating-point config value."

--- a/src/dymad/training/helper.py
+++ b/src/dymad/training/helper.py
@@ -377,7 +377,9 @@ def bounded_nelder_mead_search_points(
     if not np.all(np.isfinite(lower)) or not np.all(np.isfinite(upper)):
         raise ValueError("bounds must be finite")
     if np.any(lower >= upper):
-        raise ValueError("each lower bound must be strictly less than the corresponding upper bound")
+        raise ValueError(
+            "each lower bound must be strictly less than the corresponding upper bound"
+        )
     if not isinstance(reflection, (int, float)) or float(reflection) <= 0.0:
         raise ValueError("reflection must be a positive number")
     if not isinstance(expansion, (int, float)) or float(expansion) <= 1.0:

--- a/src/dymad/training/phases.py
+++ b/src/dymad/training/phases.py
@@ -11,13 +11,12 @@ from typing import Any, cast
 
 import numpy as np
 import torch
-from scipy.signal import savgol_filter
 from torch.utils.data import DataLoader
 
 from dymad.core import GraphSeries, GraphTrainerBatch, RegularSeries, RegularTrainerBatch
 from dymad.core.transform_builder import build_transform_module
 from dymad.losses import LOSS_MAP
-from dymad.numerics import generate_weak_weights
+from dymad.numerics import denoise, denoising_metrics, generate_weak_weights
 from dymad.training.batch_adapter import RuntimeBatch, TrainerBatch, batch_to_runtime
 from dymad.training.execution_services import ExecutionServices
 from dymad.training.ls_update import LSUpdater
@@ -1577,31 +1576,37 @@ class ContextDataPhase(BasePhase):
             "cval": cval,
         }
 
-    def _smooth_tensor(self, tensor: torch.Tensor, *, savgol_cfg: dict[str, Any]) -> torch.Tensor:
-        if tensor.shape[0] < savgol_cfg["window_length"]:
+    def _smooth_tensor(
+        self,
+        tensor: torch.Tensor,
+        *,
+        method: str,
+        denoise_cfg: dict[str, Any],
+    ) -> torch.Tensor:
+        if tensor.shape[0] < denoise_cfg["window_length"]:
             raise PhaseSpecValidationError(
                 f"Data phase '{self.spec.name}' requires every selected trajectory to have at least "
-                f"{savgol_cfg['window_length']} steps."
+                f"{denoise_cfg['window_length']} steps."
             )
-        smoothed = savgol_filter(
-            tensor.detach().cpu().numpy(),
-            axis=0,
-            **savgol_cfg,
-        )
-        return torch.as_tensor(smoothed, device=tensor.device, dtype=tensor.dtype)
+        return cast(torch.Tensor, denoise(tensor, method=method, axis=0, **denoise_cfg))
 
     def _smooth_series(
         self,
         series: TrainerBatch,
         *,
-        savgol_cfg: dict[str, Any],
+        method: str,
+        denoise_cfg: dict[str, Any],
     ) -> TrainerBatch:
         if isinstance(series, RegularSeries):
-            return series.with_state(self._smooth_tensor(series.state, savgol_cfg=savgol_cfg))
+            return series.with_state(
+                self._smooth_tensor(series.state, method=method, denoise_cfg=denoise_cfg)
+            )
         if isinstance(series, GraphSeries):
             return replace(
                 series,
-                node_state=self._smooth_tensor(series.node_state, savgol_cfg=savgol_cfg),
+                node_state=self._smooth_tensor(
+                    series.node_state, method=method, denoise_cfg=denoise_cfg
+                ),
                 meta=dict(series.meta),
             )
         raise TypeError(f"Unsupported dataset item type '{type(series)}' for smoothing.")
@@ -1645,55 +1650,11 @@ class ContextDataPhase(BasePhase):
             raise ValueError(
                 f"Smoothing metrics require matching dataset lengths for split '{split}'."
             )
-
-        sum_sq_delta = 0.0
-        sum_abs_delta = 0.0
-        max_abs_delta = 0.0
-        sum_sq_signal = 0.0
-        n_elements = 0
-        sum_sq_diff_before = 0.0
-        sum_sq_diff_after = 0.0
-        n_diff_elements = 0
-
-        for before_series, after_series in zip(original, smoothed, strict=False):
-            before = self._series_signal_array(before_series)
-            after = self._series_signal_array(after_series)
-            delta = after - before
-
-            sum_sq_delta += float(np.square(delta).sum())
-            sum_abs_delta += float(np.abs(delta).sum())
-            max_abs_delta = max(max_abs_delta, float(np.abs(delta).max(initial=0.0)))
-            sum_sq_signal += float(np.square(before).sum())
-            n_elements += int(delta.size)
-
-            if before.shape[0] > 1:
-                diff_before = np.diff(before, axis=0)
-                diff_after = np.diff(after, axis=0)
-                sum_sq_diff_before += float(np.square(diff_before).sum())
-                sum_sq_diff_after += float(np.square(diff_after).sum())
-                n_diff_elements += int(diff_before.size)
-
-        delta_rmse = float(np.sqrt(sum_sq_delta / n_elements)) if n_elements > 0 else 0.0
-        signal_rms = float(np.sqrt(sum_sq_signal / n_elements)) if n_elements > 0 else 0.0
-        roughness_before = sum_sq_diff_before / n_diff_elements if n_diff_elements > 0 else 0.0
-        roughness_after = sum_sq_diff_after / n_diff_elements if n_diff_elements > 0 else 0.0
-        if roughness_before > 0.0:
-            roughness_ratio = roughness_after / roughness_before
-        elif roughness_after == 0.0:
-            roughness_ratio = 1.0
-        else:
-            roughness_ratio = float("inf")
-
-        return {
-            f"{split}_delta_rmse": delta_rmse,
-            f"{split}_delta_mae": sum_abs_delta / n_elements if n_elements > 0 else 0.0,
-            f"{split}_delta_max_abs": max_abs_delta,
-            f"{split}_delta_rel_rmse": (delta_rmse / signal_rms) if signal_rms > 0.0 else 0.0,
-            f"{split}_roughness_before": roughness_before,
-            f"{split}_roughness_after": roughness_after,
-            f"{split}_roughness_delta": roughness_after - roughness_before,
-            f"{split}_roughness_ratio": roughness_ratio,
-        }
+        metrics = denoising_metrics(
+            original=[self._series_signal_array(series) for series in original],
+            denoised=[self._series_signal_array(series) for series in smoothed],
+        )
+        return {f"{split}_{key}": value for key, value in metrics.items()}
 
     def _apply_smoothing(
         self,
@@ -1702,7 +1663,7 @@ class ContextDataPhase(BasePhase):
     ) -> tuple[PhaseContext, dict[str, float]]:
         method = self._resolve_smoothing_method()
         splits = self._resolve_smoothing_splits()
-        savgol_cfg = self._resolve_savgol_config()
+        denoise_cfg = self._resolve_savgol_config()
         metrics: dict[str, float] = {}
 
         train_set = phase_context.train_set
@@ -1713,7 +1674,8 @@ class ContextDataPhase(BasePhase):
                     f"Data phase '{self.spec.name}' cannot smooth the train split because it is missing."
                 )
             smoothed_train = [
-                self._smooth_series(series, savgol_cfg=savgol_cfg) for series in train_set
+                self._smooth_series(series, method=method, denoise_cfg=denoise_cfg)
+                for series in train_set
             ]
             train_metrics = self._compute_smoothing_metrics(
                 original=train_set,
@@ -1725,7 +1687,7 @@ class ContextDataPhase(BasePhase):
             train_md = self._append_phase_history(
                 phase_context.train_md,
                 method=method,
-                savgol_cfg=savgol_cfg,
+                savgol_cfg=denoise_cfg,
                 metrics=train_metrics,
                 split="train",
                 dataset=train_set,
@@ -1739,7 +1701,8 @@ class ContextDataPhase(BasePhase):
                     f"Data phase '{self.spec.name}' cannot smooth the valid split because it is missing."
                 )
             smoothed_valid = [
-                self._smooth_series(series, savgol_cfg=savgol_cfg) for series in valid_set
+                self._smooth_series(series, method=method, denoise_cfg=denoise_cfg)
+                for series in valid_set
             ]
             valid_metrics = self._compute_smoothing_metrics(
                 original=valid_set,
@@ -1751,7 +1714,7 @@ class ContextDataPhase(BasePhase):
             valid_md = self._append_phase_history(
                 phase_context.valid_md,
                 method=method,
-                savgol_cfg=savgol_cfg,
+                savgol_cfg=denoise_cfg,
                 metrics=valid_metrics,
                 split="valid",
                 dataset=valid_set,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 import os
 import shutil
+import sys
 from pathlib import Path
 
 import numpy as np
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from dymad.utils import TrajectorySampler, adj_to_edge
 

--- a/tests/test_agent_training_compiler.py
+++ b/tests/test_agent_training_compiler.py
@@ -208,9 +208,7 @@ def test_compile_training_request_accepts_explicit_grid_cv_metadata(tmp_path) ->
             "search": {"mode": "grid"},
         }
     }
-    assert compiled.effective_config["cv"]["param_grid"] == {
-        "model.koopman_dimension": [4, 6, 8]
-    }
+    assert compiled.effective_config["cv"]["param_grid"] == {"model.koopman_dimension": [4, 6, 8]}
     assert compiled.effective_config["cv"]["search"]["mode"] == "grid"
 
 

--- a/tests/test_assert_denoising.py
+++ b/tests/test_assert_denoising.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+import torch
+from scipy.signal import savgol_filter
+
+from dymad.numerics import denoise, denoising_metrics
+
+
+def test_denoise_savgol_matches_scipy_for_numpy_arrays():
+    data = np.stack(
+        (
+            np.linspace(0.0, 1.0, 9),
+            np.sin(np.linspace(0.0, np.pi, 9)),
+        ),
+        axis=1,
+    )
+
+    result = denoise(data, method="savgol", window_length=5, polyorder=2)
+
+    np.testing.assert_allclose(result, savgol_filter(data, 5, 2, axis=0))
+
+
+def test_denoise_savgol_preserves_torch_dtype_and_device():
+    data = torch.stack(
+        (
+            torch.linspace(0.0, 1.0, 9, dtype=torch.float32),
+            torch.cos(torch.linspace(0.0, 1.0, 9, dtype=torch.float32)),
+        ),
+        dim=1,
+    )
+
+    result = denoise(data, method="savgol", window_length=5, polyorder=2)
+
+    assert isinstance(result, torch.Tensor)
+    assert result.dtype is data.dtype
+    assert result.device == data.device
+    np.testing.assert_allclose(
+        result.detach().cpu().numpy(),
+        savgol_filter(data.detach().cpu().numpy(), 5, 2, axis=0),
+    )
+
+
+def test_denoising_metrics_aggregate_multiple_signals():
+    original = [
+        np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 1.0]]),
+        np.array([[1.0, -1.0], [2.0, 0.0], [3.0, 1.0]]),
+    ]
+    denoised = [
+        np.array([[0.0, 0.0], [0.5, 1.5], [1.5, 1.0]]),
+        np.array([[1.0, -0.5], [1.5, 0.5], [2.5, 1.5]]),
+    ]
+
+    metrics = denoising_metrics(original=original, denoised=denoised)
+
+    deltas = [after - before for before, after in zip(original, denoised, strict=False)]
+    n_elements = sum(delta.size for delta in deltas)
+    sum_sq_delta = sum(float(np.square(delta).sum()) for delta in deltas)
+    sum_abs_delta = sum(float(np.abs(delta).sum()) for delta in deltas)
+    max_abs_delta = max(float(np.abs(delta).max(initial=0.0)) for delta in deltas)
+    sum_sq_signal = sum(float(np.square(signal).sum()) for signal in original)
+    diffs_before = [np.diff(signal, axis=0) for signal in original]
+    diffs_after = [np.diff(signal, axis=0) for signal in denoised]
+    n_diff_elements = sum(diff.size for diff in diffs_before)
+    roughness_before = sum(float(np.square(diff).sum()) for diff in diffs_before) / n_diff_elements
+    roughness_after = sum(float(np.square(diff).sum()) for diff in diffs_after) / n_diff_elements
+    delta_rmse = float(np.sqrt(sum_sq_delta / n_elements))
+    signal_rms = float(np.sqrt(sum_sq_signal / n_elements))
+
+    assert metrics["delta_rmse"] == pytest.approx(delta_rmse)
+    assert metrics["delta_mae"] == pytest.approx(sum_abs_delta / n_elements)
+    assert metrics["delta_max_abs"] == pytest.approx(max_abs_delta)
+    assert metrics["delta_rel_rmse"] == pytest.approx(delta_rmse / signal_rms)
+    assert metrics["roughness_before"] == pytest.approx(roughness_before)
+    assert metrics["roughness_after"] == pytest.approx(roughness_after)
+    assert metrics["roughness_delta"] == pytest.approx(roughness_after - roughness_before)
+    assert metrics["roughness_ratio"] == pytest.approx(roughness_after / roughness_before)
+
+
+def test_denoise_rejects_unknown_method():
+    with pytest.raises(ValueError, match="Unsupported denoising method"):
+        denoise(np.ones((9, 2)), method="median")

--- a/tests/test_contract_training_phase_runtime.py
+++ b/tests/test_contract_training_phase_runtime.py
@@ -428,6 +428,73 @@ def test_smoothing_data_phase_logs_train_valid_table(caplog):
     assert "num_elements" not in caplog.text
 
 
+def test_smoothing_data_phase_uses_standalone_denoising_helpers(monkeypatch):
+    train_series = _build_regular_series()
+    context = PhaseContext(
+        train_set=[train_series],
+        valid_set=None,
+        train_loader=object(),
+        valid_loader=None,
+        train_md={"dt_and_n_steps": [(0.1, 9)]},
+        valid_md=None,
+    )
+    config = {
+        "model": {"name": "demo"},
+        "dataloader": {"batch_size": 1, "shuffle": False},
+        "phases": [],
+    }
+    phase = _build_data_phase(
+        config,
+        DataPhaseSpec(
+            name="smooth_train",
+            operation="smooth",
+            config={"splits": ["train"], "window_length": 5, "polyorder": 2},
+        ),
+    )
+    calls: dict[str, object] = {}
+
+    def fake_denoise(data, *, method, axis=0, **kwargs):
+        calls["denoise"] = {
+            "method": method,
+            "axis": axis,
+            "window_length": kwargs["window_length"],
+            "polyorder": kwargs["polyorder"],
+        }
+        return data + 1.0
+
+    def fake_metrics(*, original, denoised):
+        calls["metrics"] = {
+            "num_original": len(original),
+            "num_denoised": len(denoised),
+        }
+        return {"delta_rmse": 2.5, "roughness_ratio": 0.4}
+
+    monkeypatch.setattr(phases_module, "denoise", fake_denoise)
+    monkeypatch.setattr(phases_module, "denoising_metrics", fake_metrics)
+
+    result = phase.execute(
+        trainer_state=TrainerState(config=config, device=torch.device("cpu")),
+        phase_context=context,
+        artifacts=ArtifactRegistry(),
+        run_name="demo",
+        logger=logging.getLogger("test.smooth.delegate"),
+    )
+
+    assert calls["denoise"] == {
+        "method": "savgol",
+        "axis": 0,
+        "window_length": 5,
+        "polyorder": 2,
+    }
+    assert calls["metrics"] == {"num_original": 1, "num_denoised": 1}
+    np.testing.assert_allclose(
+        result.phase_context.train_set[0].state.detach().cpu().numpy(),
+        train_series.state.detach().cpu().numpy() + 1.0,
+    )
+    assert result.metrics["train_delta_rmse"] == pytest.approx(2.5)
+    assert result.metrics["train_roughness_ratio"] == pytest.approx(0.4)
+
+
 def test_smoothing_data_phase_supports_train_only_split():
     train_series = _build_regular_series()
     valid_series = _build_regular_series(offset=0.2)
@@ -1199,6 +1266,7 @@ cv:
         _fake_init_trajectory_managers,
     )
     monkeypatch.setattr(driver.SingleSplitDriver, "_init_fold_split", lambda self: None)
+
     def _fake_nelder_mead_like_search_indices(combos, *, evaluate_index, **kwargs):
         evaluated = [0, 8, 2, 5, 7, 4, 1, 3]
         for index in evaluated:


### PR DESCRIPTION
Closes #33

## Summary
This PR was generated by the local AI issue worker.

## Verification
PASS make check
exit code: 0
duration: 5.13s
stdout:
ruff check .
All checks passed!
ruff format . --check
263 files already formatted
pyright --pythonpath "/Users/daninghuang/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations
WARNING: there is a new pyright version available (v1.1.408 -> v1.1.409).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`


stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 96.66s
stdout:
UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

tests/test_workflow_sa_lti.py::test_sa[4]
  /Users/daninghuang/Repos/dymad-dev/.ai-worktrees/issue-33/src/dymad/sako/sako.py:172: RuntimeWarning: invalid value encountered in multiply
    _G = self._M11 - l * self._M10 - np.conj(l) * self._M01 + np.abs(l) ** 2 * self._M00

tests/test_workflow_sa_lti.py::test_sa[4]
  /Users/daninghuang/Repos/dymad-dev/.ai-worktrees/issue-33/src/dymad/sako/sako.py:172: RuntimeWarning: invalid value encountered in subtract
    _G = self._M11 - l * self._M10 - np.conj(l) * self._M01 + np.abs(l) ** 2 * self._M00

tests/test_workflow_sa_lti.py::test_sa[4]
  /Users/daninghuang/Repos/dymad-dev/.ai-worktrees/issue-33/src/dymad/sako/sako.py:172: RuntimeWarning: invalid value encountered in add
    _G = self._M11 - l * self._M10 - np.conj(l) * self._M01 + np.abs(l) ** 2 * self._M00

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 376 passed, 71 deselected, 32 warnings in 92.81s (0:01:32) ==========

stderr:

## Changed files
- scripts/denoise/noise_train.py
- scripts/linear_time_invariant/lti_nm.py
- src/dymad/numerics/__init__.py
- src/dymad/training/driver.py
- src/dymad/training/helper.py
- src/dymad/training/phases.py
- tests/conftest.py
- tests/test_agent_training_compiler.py
- tests/test_contract_training_phase_runtime.py
- src/dymad/numerics/denoising.py
- tests/test_assert_denoising.py

## Agent notes
See diff for implementation details.
