### PR TITLE
Fix #39: Add nonlinear one-step trainer phase

### DIFF
--- a/src/dymad/agent/exec/workflow.py
+++ b/src/dymad/agent/exec/workflow.py
@@ -238,7 +238,13 @@ def _effective_config(
 
 
 def _select_trainer(config: dict[str, Any]):
-    from dymad.training import LinearTrainer, NODETrainer, StackedTrainer, WeakFormTrainer
+    from dymad.training import (
+        LinearTrainer,
+        NODETrainer,
+        OneStepTrainer,
+        StackedTrainer,
+        WeakFormTrainer,
+    )
 
     phases = config.get("phases")
     if not isinstance(phases, list) or not phases:
@@ -259,6 +265,8 @@ def _select_trainer(config: dict[str, Any]):
         return WeakFormTrainer, "weak_form"
     if trainer == "Linear":
         return LinearTrainer, "linear"
+    if trainer == "OneStep":
+        return OneStepTrainer, "one_step"
     raise ValueError(f"unsupported trainer kind in phases: {trainer}")
 
 

--- a/src/dymad/agent/registry/training_schema.py
+++ b/src/dymad/agent/registry/training_schema.py
@@ -84,7 +84,7 @@ TRANSLATION_GUIDANCE: tuple[str, ...] = (
     "or 'even' for integer-valued fields. If bounds are omitted, the runtime uses the legacy "
     "adaptive walk over param_grid candidates.",
     "Use overrides.cv.selection to control model choice policy (goal and tie_breakers).",
-    "Supported optimizer trainer names are Linear, Weak, and NODE.",
+    "Supported optimizer trainer names are Linear, OneStep, Weak, and NODE.",
     "Prefer minimal legacy optimizer entries such as {'trainer': 'Linear'} or "
     "{'trainer': 'Weak'} unless the user asks for explicit phase-level hyperparameters; "
     "matching trainer defaults from the selected profile are preserved unless overridden.",
@@ -106,10 +106,10 @@ def _phase_entry_schemas() -> tuple[TrainingPhaseEntrySchema, ...]:
         TrainingPhaseEntrySchema(
             key="legacy_optimizer",
             summary="Legacy shorthand for one optimizer phase.",
-            accepted_shape='{"trainer": "NODE" | "Weak" | "Linear", ...}',
+            accepted_shape='{"trainer": "NODE" | "Weak" | "Linear" | "OneStep", ...}',
             required_fields=("trainer",),
             optional_fields=("name",),
-            enum_fields={"trainer": ("NODE", "Weak", "Linear")},
+            enum_fields={"trainer": ("NODE", "Weak", "Linear", "OneStep")},
             allows_additional_keys=True,
             notes=(
                 "Any extra keys are treated as optimizer-phase config.",
@@ -120,10 +120,10 @@ def _phase_entry_schemas() -> tuple[TrainingPhaseEntrySchema, ...]:
         TrainingPhaseEntrySchema(
             key="optimizer",
             summary="Explicit optimizer phase.",
-            accepted_shape='{"type": "optimizer", "trainer": "NODE" | "Weak" | "Linear", ...}',
+            accepted_shape='{"type": "optimizer", "trainer": "NODE" | "Weak" | "Linear" | "OneStep", ...}',
             required_fields=("type", "trainer"),
             optional_fields=("name",),
-            enum_fields={"trainer": ("NODE", "Weak", "Linear")},
+            enum_fields={"trainer": ("NODE", "Weak", "Linear", "OneStep")},
             allows_additional_keys=True,
             notes=("Any extra keys are treated as optimizer-phase config.",),
             example={"type": "optimizer", "name": "Refine", "trainer": "NODE", "n_epochs": 25},
@@ -237,7 +237,7 @@ def _examples() -> tuple[TrainingCapabilityExample, ...]:
             },
             notes=(
                 "The same ordered-trainer translation rule applies to any supported "
-                "mix of Linear, Weak, and NODE phases.",
+                "mix of Linear, OneStep, Weak, and NODE phases.",
             ),
         ),
         TrainingCapabilityExample(

--- a/src/dymad/training/__init__.py
+++ b/src/dymad/training/__init__.py
@@ -31,7 +31,13 @@ from dymad.training.phases import (
     PhaseSpecValidationError,
     normalize_phase_specs,
 )
-from dymad.training.trainer import LinearTrainer, NODETrainer, StackedTrainer, WeakFormTrainer
+from dymad.training.trainer import (
+    LinearTrainer,
+    NODETrainer,
+    OneStepTrainer,
+    StackedTrainer,
+    WeakFormTrainer,
+)
 from dymad.training.trainer_run import TrainerRun
 
 __all__ = [
@@ -52,6 +58,7 @@ __all__ = [
     "ModelArtifact",
     "NODETrainer",
     "normalize_phase_specs",
+    "OneStepTrainer",
     "OptimizerPhaseSpec",
     "OptimizerStateArtifact",
     "PhaseContext",

--- a/src/dymad/training/ls_update.py
+++ b/src/dymad/training/ls_update.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 # ----------------
 def _dt_target(z: torch.Tensor) -> torch.Tensor:
     """Compute discrete-time targets."""
-    return z[..., 1:, :]
+    return z[..., 1:, :].detach()
 
 
 def _as_runtime_batch(batch: TrainerBatch | RuntimeBatch) -> RuntimeBatch:
@@ -71,9 +71,9 @@ def _ct_target(z: torch.Tensor, dt, order=2) -> torch.Tensor:
     if order == 1:
         dz = (z[..., 1:, :] - z[..., :-1, :]) / dt
         dz = torch.concatenate((dz, dz[..., -1:, :]), dim=-2)
-        return dz
+        return dz.detach()
     elif order == 2:
-        dz = np.gradient(z.cpu().numpy(), dt, axis=-2, edge_order=2)
+        dz = np.gradient(z.detach().cpu().numpy(), dt, axis=-2, edge_order=2)
         return torch.tensor(dz, dtype=z.dtype, device=z.device)
     else:
         raise ValueError(f"Unsupported FD order: {order}. Only 1 and 2 are supported.")

--- a/src/dymad/training/phase_runtime.py
+++ b/src/dymad/training/phase_runtime.py
@@ -39,6 +39,8 @@ class OptimizerStateArtifact:
     _weak_N: int | None = None
     _weak_dN: int | None = None
     _linear_updater: LSUpdater | None = None
+    _one_step_dt: float | None = None
+    _one_step_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/dymad/training/phases.py
+++ b/src/dymad/training/phases.py
@@ -19,7 +19,7 @@ from dymad.losses import LOSS_MAP
 from dymad.numerics import denoise, denoising_metrics, generate_weak_weights
 from dymad.training.batch_adapter import RuntimeBatch, TrainerBatch, batch_to_runtime
 from dymad.training.execution_services import ExecutionServices
-from dymad.training.ls_update import LSUpdater
+from dymad.training.ls_update import LSUpdater, _comp_linear_eval_ct, _comp_linear_eval_dt
 from dymad.training.phase_runtime import (
     ArtifactRegistry,
     EvaluationArtifact,
@@ -215,9 +215,9 @@ def _determine_chop_step(window: int, step: int | float) -> int:
 
 
 def _normalize_legacy_optimizer_name(trainer: str) -> str:
-    if trainer not in {"NODE", "Weak", "Linear"}:
+    if trainer not in {"NODE", "Weak", "Linear", "OneStep"}:
         raise PhaseSpecValidationError(
-            f"Unsupported trainer '{trainer}'. Expected one of NODE, Weak, Linear."
+            f"Unsupported trainer '{trainer}'. Expected one of NODE, Weak, Linear, OneStep."
         )
     return trainer
 
@@ -495,7 +495,7 @@ class BasePhase:
                 continue
             phase_type = phase_cfg.get("type")
             trainer_name = phase_cfg.get("trainer")
-            if phase_type == "optimizer" or trainer_name in {"NODE", "Weak", "Linear"}:
+            if phase_type == "optimizer" or trainer_name in {"NODE", "Weak", "Linear", "OneStep"}:
                 return (
                     phase_cfg.get("ode_method", "dopri5"),
                     copy.deepcopy(phase_cfg.get("ode_args", {})),
@@ -1383,6 +1383,75 @@ class LinearRegressionPhase(BaseOptimizerPhase):
         return float(avg_loss), items, False
 
 
+class OneStepOptimizerPhase(BaseOptimizerPhase):
+    def _customize_optimizer_artifact(
+        self,
+        optimizer_state: OptimizerStateArtifact,
+        model: torch.nn.Module,
+        phase_context: PhaseContext,
+        phase_logger: logging.Logger,
+    ) -> None:
+        del model, phase_logger
+        train_md = _require_metadata(phase_context.train_md)
+        optimizer_state._one_step_dt = float(train_md["dt_and_n_steps"][0][0])
+        optimizer_state._one_step_kwargs = {}
+        kwargs_cfg = self.spec.config.get("kwargs", {})
+        if isinstance(kwargs_cfg, dict):
+            optimizer_state._one_step_kwargs.update(copy.deepcopy(kwargs_cfg))
+        if "order" in self.spec.config:
+            optimizer_state._one_step_kwargs["order"] = self.spec.config["order"]
+
+    def _compute_losses(
+        self,
+        model: torch.nn.Module,
+        optimizer_state: OptimizerStateArtifact,
+        batch: TrainerBatch,
+        ode_method: str,
+        ode_args: dict[str, Any],
+    ) -> list[torch.Tensor]:
+        batch_any = cast(Any, batch)
+        if getattr(batch_any, "is_ragged", False):
+            return self._average_loss_lists(
+                [
+                    self._compute_losses(model, optimizer_state, sample, ode_method, ode_args)
+                    for sample in batch_any.iter_single_batches()
+                ]
+            )
+
+        dt = optimizer_state._one_step_dt
+        if dt is None:
+            raise ValueError("One-step target time step is not initialized.")
+
+        runtime_batch = batch_any.to(self.device)
+        if getattr(model, "CONT", False):
+            predictions, targets = _comp_linear_eval_ct(
+                model,
+                runtime_batch,
+                dt=dt,
+                **optimizer_state._one_step_kwargs,
+            )
+        else:
+            predictions, targets = _comp_linear_eval_dt(
+                model,
+                runtime_batch,
+                dt=dt,
+                **optimizer_state._one_step_kwargs,
+            )
+        losses = [optimizer_state.criteria[0](predictions, targets)]
+        losses.extend(
+            self._additional_criteria_evaluation(
+                model,
+                optimizer_state,
+                None,
+                None,
+                runtime_batch,
+                ode_method,
+                ode_args,
+            )
+        )
+        return losses
+
+
 class LinearSolvePhase(BasePhase):
     def execute(
         self,
@@ -2062,6 +2131,14 @@ def build_phase(
             )
         if spec.trainer == "Linear":
             return LinearRegressionPhase(
+                spec=spec,
+                config=config,
+                model_class=model_class,
+                dtype=dtype,
+                execution_services=execution_services,
+            )
+        if spec.trainer == "OneStep":
+            return OneStepOptimizerPhase(
                 spec=spec,
                 config=config,
                 model_class=model_class,

--- a/src/dymad/training/trainer.py
+++ b/src/dymad/training/trainer.py
@@ -99,6 +99,32 @@ class LinearTrainer(SingleSplitDriver):
         ]
 
 
+class OneStepTrainer(SingleSplitDriver):
+    """
+    Simple interface for single-split single-stage training by nonlinear one-step optimization.
+    """
+
+    def __init__(
+        self,
+        config_path: str,
+        model_class: type[torch.nn.Module],
+        config_mod: dict[str, Any] | None = None,
+        device: torch.device | None = None,
+        max_workers: int = 1,
+    ):
+        super().__init__(
+            config_path=config_path,
+            model_class=model_class,
+            config_mod=config_mod,
+            device=device,
+            max_workers=max_workers,
+        )
+
+        self.base_config["phases"] = [
+            _select_single_stage_phase(self.base_config, name="OneStep", trainer="OneStep")
+        ]
+
+
 class StackedTrainer(SingleSplitDriver):
     """
     Simple interface for single-split phased training.

--- a/tests/test_agent_mcp_user_tools.py
+++ b/tests/test_agent_mcp_user_tools.py
@@ -107,7 +107,7 @@ def test_user_tools_compile_start_poll_and_evaluate_flow(tmp_path, monkeypatch) 
     )
     assert (
         detail["data"]["detail"]["translation_guidance"][4]
-        == "Supported optimizer trainer names are Linear, Weak, and NODE."
+        == "Supported optimizer trainer names are Linear, OneStep, Weak, and NODE."
     )
     assert detail["data"]["detail"]["cv_schema"] == {
         "supported": True,
@@ -182,7 +182,7 @@ def test_user_tools_compile_start_poll_and_evaluate_flow(tmp_path, monkeypatch) 
         },
         "notes": [
             "The same ordered-trainer translation rule applies to any supported mix of "
-            "Linear, Weak, and NODE phases."
+            "Linear, OneStep, Weak, and NODE phases."
         ],
     }
     assert detail["data"]["detail"]["examples"][2] == {

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -175,7 +175,7 @@ def test_describe_training_capability_exposes_phase_schema_and_override_contract
         "parity='odd' or 'even' for integer-valued fields. If bounds are omitted, the runtime "
         "uses the legacy adaptive walk over param_grid candidates.",
         "Use overrides.cv.selection to control model choice policy (goal and tie_breakers).",
-        "Supported optimizer trainer names are Linear, Weak, and NODE.",
+        "Supported optimizer trainer names are Linear, OneStep, Weak, and NODE.",
         "Prefer minimal legacy optimizer entries such as {'trainer': 'Linear'} or "
         "{'trainer': 'Weak'} unless the user asks for explicit phase-level hyperparameters; "
         "matching trainer defaults from the selected profile are preserved unless overridden.",

--- a/tests/test_agent_training_compiler.py
+++ b/tests/test_agent_training_compiler.py
@@ -645,6 +645,7 @@ def test_compile_training_request_accepts_minimal_staged_legacy_optimizer_shorth
     ("phase_sequence", "expected_trainers"),
     [
         ([{"trainer": "Linear"}, {"trainer": "Weak"}], ["Linear", "Weak"]),
+        ([{"trainer": "OneStep"}, {"trainer": "NODE"}], ["OneStep", "NODE"]),
         ([{"trainer": "Weak"}, {"trainer": "NODE"}], ["Weak", "NODE"]),
     ],
 )

--- a/tests/test_contract_public_reexport_surfaces.py
+++ b/tests/test_contract_public_reexport_surfaces.py
@@ -100,6 +100,7 @@ EXPECTED_TRAINING_SURFACE = {
     "ModelArtifact",
     "NODETrainer",
     "normalize_phase_specs",
+    "OneStepTrainer",
     "OptimizerPhaseSpec",
     "OptimizerStateArtifact",
     "PhaseContext",

--- a/tests/test_contract_training_phase_runtime.py
+++ b/tests/test_contract_training_phase_runtime.py
@@ -15,6 +15,7 @@ from dymad.training.helper import (
     nelder_mead_like_search_indices,
     select_best_cv_result,
 )
+from dymad.training.ls_update import _comp_linear_eval_ct, _comp_linear_eval_dt
 from dymad.training.phase_runtime import (
     ArtifactRegistry,
     ModelArtifact,
@@ -813,6 +814,251 @@ def test_run_cv_single_uses_trainer_run_with_typed_context(monkeypatch):
     assert calls["results_prefix"] == "/tmp/rp"
     assert calls["execution_services"] is not None
     assert result["metric_value"] == expected_metric
+
+
+def test_one_step_optimizer_phase_uses_discrete_next_state_targets():
+    class _DiscreteModel(torch.nn.Module):
+        CONT = False
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+        def linear_eval(self, runtime):
+            z = runtime.x
+            return self.weight * z, z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(name="one_step", trainer="OneStep", config={}),
+        config=config,
+        model_class=_DiscreteModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _DiscreteModel()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[torch.nn.MSELoss(), torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+        _one_step_dt=1.0,
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0]),
+        state=torch.tensor([[1.0], [2.0], [4.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    losses = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})
+
+    assert losses[0].item() == pytest.approx(2.5)
+
+
+def test_one_step_optimizer_phase_uses_continuous_rate_targets():
+    class _ContinuousModel(torch.nn.Module):
+        CONT = True
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+        def linear_eval(self, runtime):
+            z = runtime.x
+            return self.weight * z, z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(name="one_step", trainer="OneStep", config={"order": 1}),
+        config=config,
+        model_class=_ContinuousModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _ContinuousModel()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[torch.nn.MSELoss(), torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+        _one_step_dt=1.0,
+        _one_step_kwargs={"order": 1},
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0]),
+        state=torch.tensor([[0.0], [1.0], [4.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    losses = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})
+
+    assert losses[0].item() == pytest.approx(2.0)
+
+
+def test_one_step_optimizer_phase_supports_default_continuous_targets_with_trainable_encoder():
+    class _ContinuousEncoderModel(torch.nn.Module):
+        CONT = True
+
+        def __init__(self):
+            super().__init__()
+            self.encoder_scale = torch.nn.Parameter(torch.tensor(2.0))
+            self.prediction_scale = torch.nn.Parameter(torch.tensor(0.5))
+
+        def encoder(self, runtime):
+            return self.encoder_scale * runtime.x
+
+        def linear_eval(self, runtime):
+            z = self.encoder(runtime)
+            return self.prediction_scale * z, z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(name="one_step", trainer="OneStep", config={}),
+        config=config,
+        model_class=_ContinuousEncoderModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _ContinuousEncoderModel()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[torch.nn.MSELoss(), torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+        _one_step_dt=1.0,
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0]),
+        state=torch.tensor([[0.0], [1.0], [4.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    losses = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})
+    losses[0].backward()
+
+    assert torch.isfinite(losses[0])
+    assert model.encoder_scale.grad is not None
+    assert model.encoder_scale.grad.item() != pytest.approx(0.0)
+
+
+def test_one_step_optimizer_phase_detaches_discrete_targets_for_trainable_encoder():
+    class _DiscreteEncoderModel(torch.nn.Module):
+        CONT = False
+
+        def __init__(self):
+            super().__init__()
+            self.encoder_scale = torch.nn.Parameter(torch.tensor(2.0))
+            self.prediction_scale = torch.nn.Parameter(torch.tensor(0.5))
+
+        def encoder(self, runtime):
+            return self.encoder_scale * runtime.x
+
+        def linear_eval(self, runtime):
+            z = self.encoder(runtime)
+            return self.prediction_scale * z, z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(name="one_step", trainer="OneStep", config={}),
+        config=config,
+        model_class=_DiscreteEncoderModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _DiscreteEncoderModel()
+    criterion = torch.nn.MSELoss()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[criterion, torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+        _one_step_dt=1.0,
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0]),
+        state=torch.tensor([[1.0], [2.0], [4.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    loss = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})[0]
+    actual_grad = torch.autograd.grad(loss, model.encoder_scale)[0]
+
+    runtime_batch = batch.to(phase.device)
+    predictions, targets = _comp_linear_eval_dt(model, runtime_batch, dt=1.0)
+    expected_loss = criterion(predictions, targets.detach())
+    expected_grad = torch.autograd.grad(expected_loss, model.encoder_scale)[0]
+
+    assert targets.requires_grad is False
+    assert actual_grad is not None
+    assert actual_grad.item() == pytest.approx(expected_grad.item())
+
+
+def test_one_step_optimizer_phase_detaches_first_order_continuous_targets_for_trainable_encoder():
+    class _ContinuousEncoderModel(torch.nn.Module):
+        CONT = True
+
+        def __init__(self):
+            super().__init__()
+            self.encoder_scale = torch.nn.Parameter(torch.tensor(2.0))
+            self.prediction_scale = torch.nn.Parameter(torch.tensor(0.5))
+
+        def encoder(self, runtime):
+            return self.encoder_scale * runtime.x
+
+        def linear_eval(self, runtime):
+            z = self.encoder(runtime)
+            return self.prediction_scale * z, z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(name="one_step", trainer="OneStep", config={"order": 1}),
+        config=config,
+        model_class=_ContinuousEncoderModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _ContinuousEncoderModel()
+    criterion = torch.nn.MSELoss()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[criterion, torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+        _one_step_dt=1.0,
+        _one_step_kwargs={"order": 1},
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0]),
+        state=torch.tensor([[0.0], [1.0], [4.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    loss = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})[0]
+    actual_grad = torch.autograd.grad(loss, model.encoder_scale)[0]
+
+    runtime_batch = batch.to(phase.device)
+    predictions, targets = _comp_linear_eval_ct(model, runtime_batch, dt=1.0, order=1)
+    expected_loss = criterion(predictions, targets.detach())
+    expected_grad = torch.autograd.grad(expected_loss, model.encoder_scale)[0]
+
+    assert targets.requires_grad is False
+    assert actual_grad is not None
+    assert actual_grad.item() == pytest.approx(expected_grad.item())
 
 
 def test_select_best_cv_result_uses_goal_and_tie_breakers() -> None:

--- a/tests/test_workflow_kp.py
+++ b/tests/test_workflow_kp.py
@@ -17,7 +17,13 @@ import torch
 import dymad.training.driver as training_driver
 from dymad.io import load_model
 from dymad.models import DKBF, DLDM, KBF, LDM
-from dymad.training import LinearTrainer, NODETrainer, StackedTrainer, WeakFormTrainer
+from dymad.training import (
+    LinearTrainer,
+    NODETrainer,
+    OneStepTrainer,
+    StackedTrainer,
+    WeakFormTrainer,
+)
 
 mdl_kb = {
     "name": "kp_model",
@@ -89,6 +95,16 @@ trn_dt = {
     "sweep_epoch_step": 5,
     "chop_mode": "initial",
 }
+trn_os = {
+    "n_epochs": 5,
+    "save_interval": 5,
+    "load_checkpoint": False,
+    "learning_rate": 5e-3,
+    "decay_rate": 0.999,
+}
+trn_nd_warm = copy.deepcopy(trn_nd)
+trn_nd_warm["n_epochs"] = 5
+trn_nd_warm["sweep_lengths"] = [10]
 trn_ln = {
     "n_epochs": 1,
     "save_interval": 1,
@@ -159,6 +175,19 @@ cfgs = [
     ("kbf_wfls", KBF, StackedTrainer, {"model": mdl_kb, "phases": _mixed_schedule("Weak", trn_wf)}),
     ("kbf_ndls", KBF, StackedTrainer, {"model": mdl_kb, "phases": _mixed_schedule("NODE", trn_nd)}),
     ("kbf_ln", KBF, LinearTrainer, {"model": mdl_kl, "training": trn_ln}),
+    ("ldm_step", LDM, OneStepTrainer, {"model": mdl_ld, "training": trn_os}),
+    (
+        "ldm_step_node",
+        LDM,
+        StackedTrainer,
+        {
+            "model": mdl_ld,
+            "phases": [
+                _optimizer_phase("OneStep", trn_os),
+                _optimizer_phase("NODE", trn_nd_warm),
+            ],
+        },
+    ),
     ("dldm_nd", DLDM, NODETrainer, {"model": mdl_ld, "training": trn_dt}),
     ("dkbf_nd", DKBF, NODETrainer, {"model": mdl_kb, "training": trn_dt, "cv": cv}),
     (


### PR DESCRIPTION
Closes #39

## Summary
This PR was generated by the local AI issue worker.

## Verification
PASS make check
exit code: 0
duration: 4.37s
stdout:
ruff check .
All checks passed!
ruff format . --check
264 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 91.48s
stdout:
ript.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.ai-worktrees/issue-39/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 394 passed, 71 deselected, 29 warnings in 87.76s (0:01:27) ==========

stderr:

## Changed files
- src/dymad/agent/exec/workflow.py
- src/dymad/agent/registry/training_schema.py
- src/dymad/training/__init__.py
- src/dymad/training/ls_update.py
- src/dymad/training/phase_runtime.py
- src/dymad/training/phases.py
- src/dymad/training/trainer.py
- tests/test_agent_mcp_user_tools.py
- tests/test_agent_registry.py
- tests/test_agent_training_compiler.py
- tests/test_contract_public_reexport_surfaces.py
- tests/test_contract_training_phase_runtime.py
- tests/test_workflow_kp.py

## Agent notes
See diff for implementation details.
