### PR TITLE
Fix #40: Add one-step trainer DT example script

### DIFF
--- a/scripts/lti_dt/lti_dt_onestep.py
+++ b/scripts/lti_dt/lti_dt_onestep.py
@@ -1,0 +1,183 @@
+import copy
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from dymad.io import load_model
+from dymad.models import DLDM
+from dymad.training import OneStepTrainer, StackedTrainer
+from dymad.utils import TrajectorySampler, plot_summary, plot_trajectory
+
+BASE_DIR = Path(__file__).resolve().parent
+os.chdir(BASE_DIR)
+
+B = 128
+N = 501
+t_grid = np.linspace(0, 5, N)
+DATA_PATH = BASE_DIR / "data" / "lti.npz"
+
+A = np.array([[0.0, 1.0], [-1.0, -0.1]])
+
+
+def f(t, x, u):
+    return (x @ A.T) + u
+
+
+def g(t, x, u):
+    return x
+
+
+config_chr = {
+    "control": {
+        "kind": "chirp",
+        "params": {
+            "t1": 4.0,
+            "freq_range": (0.5, 2.0),
+            "amp_range": (0.5, 1.0),
+            "phase_range": (0.0, 360.0),
+        },
+    }
+}
+
+config_gau = {
+    "control": {
+        "kind": "gaussian",
+        "params": {
+            "mean": 0.5,
+            "std": 1.0,
+            "t1": 4.0,
+            "dt": 0.2,
+            "mode": "zoh",
+        },
+    }
+}
+
+mdl_ld = {
+    "name": "lti_dldm",
+    "encoder_layers": 0,
+    "processor_layers": 1,
+    "decoder_layers": 0,
+    "hidden_dimension": 32,
+    "activation": "none",
+    "weight_init": "xavier_uniform",
+    "gain": 0.01,
+}
+
+# The one-step-only run is intentionally longer because it does not get a NODE refinement phase.
+trn_step = {
+    "n_epochs": 1200,
+    "save_interval": 20,
+    "load_checkpoint": False,
+    "learning_rate": 1e-3,
+    "decay_rate": 0.999,
+}
+trn_step_warm = copy.deepcopy(trn_step)
+trn_step_warm["n_epochs"] = 300
+
+trn_node = {
+    "n_epochs": 900,
+    "save_interval": 20,
+    "load_checkpoint": False,
+    "learning_rate": 1e-3,
+    "decay_rate": 0.999,
+    "chop_mode": "initial",
+    "sweep_lengths": [3, 5, 7],
+    "sweep_epoch_step": 200,
+}
+
+
+def _optimizer_phase(trainer, cfg):
+    phase = copy.deepcopy(cfg)
+    phase.update({"type": "optimizer", "trainer": trainer})
+    return phase
+
+
+def generate_data():
+    sampler = TrajectorySampler(f, g, config=BASE_DIR / "lti_data.yaml", config_mod=config_chr)
+    ts, _xs, us, ys = sampler.sample(t_grid, batch=B)
+    DATA_PATH.parent.mkdir(exist_ok=True)
+    np.savez_compressed(DATA_PATH, t=ts, x=ys, u=us)
+    print(f"Generated data: {DATA_PATH}")
+
+
+cases = [
+    {
+        "name": "dldm_step",
+        "model": DLDM,
+        "trainer": OneStepTrainer,
+        "config_mod": {"model": mdl_ld, "training": trn_step},
+    },
+    {
+        "name": "dldm_step_node",
+        "model": DLDM,
+        "trainer": StackedTrainer,
+        "config_mod": {
+            "model": mdl_ld,
+            # Clear the legacy single-stage block from the base YAML so it does not
+            # overwrite the explicit warm-start phase during config normalization.
+            "training": None,
+            "phases": [
+                _optimizer_phase("OneStep", trn_step_warm),
+                _optimizer_phase("NODE", trn_node),
+            ],
+        },
+    },
+]
+
+IDX = [0, 1]
+labels = [cases[i]["name"] for i in IDX]
+
+ifdat = 0
+iftrn = 1
+ifplt = 1
+ifprd = 1
+
+if ifdat:
+    generate_data()
+
+if iftrn:
+    if not DATA_PATH.exists():
+        generate_data()
+    for i in IDX:
+        case = cases[i]
+        opt = copy.deepcopy(case["config_mod"])
+        opt["model"]["name"] = f"lti_{case['name']}"
+        trainer = case["trainer"](BASE_DIR / "lti_dldm.yaml", case["model"], config_mod=opt)
+        trainer.train()
+
+if ifplt:
+    npz_files = [f"lti_{label}" for label in labels]
+    npzs = plot_summary(npz_files, labels=labels, ifclose=False)
+
+    for label, npz in zip(labels, npzs, strict=False):
+        print(f"Epoch time {label}: {npz['avg_epoch_time']}")
+
+if ifprd:
+    sampler = TrajectorySampler(f, g, config=BASE_DIR / "lti_data.yaml", config_mod=config_gau)
+
+    ts, xs, us, ys = sampler.sample(t_grid, batch=1)
+    x_data = xs[0]
+    t_data = ts[0]
+    u_data = us[0]
+
+    res = [x_data]
+    for i in IDX:
+        case = cases[i]
+        _, prd_func = load_model(case["model"], f"lti_{case['name']}.pt")
+        with torch.no_grad():
+            pred = prd_func(x_data, t_data, u=u_data)
+        res.append(pred)
+
+    plot_trajectory(
+        np.array(res),
+        t_data,
+        "LTI",
+        us=u_data,
+        labels=["Truth"] + labels,
+        ifclose=False,
+    )
+
+plt.show()

--- a/tests/test_contract_training_phase_runtime.py
+++ b/tests/test_contract_training_phase_runtime.py
@@ -727,6 +727,51 @@ cv:
     assert phase._prediction_settings() == ("rk4", {"step_size": 0.2})
 
 
+def test_load_config_preserves_explicit_phases_when_training_is_disabled(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model:
+  name: demo
+training:
+  n_epochs: 1000
+  save_interval: 10
+  chop_mode: unfold
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_config(
+        str(config_path),
+        config_mod={
+            "training": None,
+            "phases": [
+                {
+                    "type": "optimizer",
+                    "name": "warm",
+                    "trainer": "OneStep",
+                    "n_epochs": 300,
+                    "save_interval": 20,
+                },
+                {
+                    "type": "optimizer",
+                    "name": "node",
+                    "trainer": "NODE",
+                    "n_epochs": 900,
+                    "chop_mode": "initial",
+                },
+            ],
+        },
+    )
+
+    assert config["training"] is None
+    assert config["phases"][0]["n_epochs"] == 300
+    assert config["phases"][0]["save_interval"] == 20
+    assert "chop_mode" not in config["phases"][0]
+    assert config["phases"][1]["n_epochs"] == 900
+    assert config["phases"][1]["chop_mode"] == "initial"
+
+
 def test_run_cv_single_uses_trainer_run_with_typed_context(monkeypatch):
     calls = {"init": 0, "run": 0}
     expected_metric = 0.123


### PR DESCRIPTION
Closes #40

## Summary
This PR was generated by the local AI issue worker.

## Verification
PASS make check
exit code: 0
duration: 4.50s
stdout:
ruff check .
All checks passed!
ruff format . --check
265 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 91.70s
stdout:
ript.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.ai-worktrees/issue-40/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 395 passed, 71 deselected, 29 warnings in 87.95s (0:01:27) ==========

stderr:

## Changed files
- tests/test_contract_training_phase_runtime.py
- scripts/lti_dt/lti_dt_onestep.py

## Agent notes
See diff for implementation details.
