### PR TITLE
Fix #41: One-step trainer example CT

### DIFF
--- a/scripts/lti_1s/lti_1s.py
+++ b/scripts/lti_1s/lti_1s.py
@@ -77,23 +77,25 @@ mdl_ld = {
 }
 
 trn_step = {
-    "n_epochs": 1200,
-    "save_interval": 20,
+    "n_epochs": 2000,
+    "save_interval": 50,
     "load_checkpoint": False,
     "learning_rate": 1e-3,
     "decay_rate": 0.999,
 }
 trn_step_warm = copy.deepcopy(trn_step)
-trn_step_warm["n_epochs"] = 300
+trn_step_warm["n_epochs"] = 1000
 
 trn_node = {
-    "n_epochs": 900,
-    "save_interval": 20,
+    "n_epochs": 1000,
+    "save_interval": 50,
     "load_checkpoint": False,
     "learning_rate": 1e-3,
     "decay_rate": 0.999,
-    "sweep_lengths": [50, 100, 200, 300, 501],
-    "sweep_epoch_step": 100,
+    "sweep_lengths": [20, 40],
+    "sweep_epoch_step": 200,
+    # "chop_mode": "unfold",
+    # "chop_step": 0.5,
     "ode_method": "dopri5",
     "ode_args": {"rtol": 1.0e-7, "atol": 1.0e-9},
 }

--- a/scripts/lti_1s/lti_1s.py
+++ b/scripts/lti_1s/lti_1s.py
@@ -100,7 +100,7 @@ trn_step_warm = copy.deepcopy(trn_step)
 trn_step_warm["n_epochs"] = 1000
 
 trn_weak = {
-    "n_epochs": 1000,
+    "n_epochs": 500,
     "save_interval": 50,
     "load_checkpoint": False,
     "learning_rate": 5e-3,
@@ -114,7 +114,7 @@ trn_weak = {
 }
 
 trn_dt_node = {
-    "n_epochs": 1000,
+    "n_epochs": 500,
     "save_interval": 50,
     "load_checkpoint": False,
     "learning_rate": 1e-3,
@@ -163,7 +163,7 @@ cases = [
             "training": None,
             "phases": [
                 _optimizer_phase("OneStep", trn_step_warm),
-                _optimizer_phase("Weak", trn_weak),
+                _optimizer_phase("Weak", {**trn_weak, "reset_optimizer": True}),
             ],
         },
     },
@@ -189,19 +189,18 @@ cases = [
             "training": None,
             "phases": [
                 _optimizer_phase("OneStep", trn_step_warm),
-                _optimizer_phase("NODE", trn_dt_node),
+                _optimizer_phase("NODE", {**trn_dt_node, "reset_optimizer": True}),
             ],
         },
     },
 ]
 
-# IDX = [0, 1, 2, 3]
-IDX = [1]
+IDX = [0, 1, 2, 3]
 labels = [cases[i]["label"] for i in IDX]
 
 ifdat = 0
-iftrn = 1
-ifplt = 1
+iftrn = 0
+ifplt = 0
 ifprd = 1
 
 if ifdat:

--- a/scripts/lti_1s/lti_1s.py
+++ b/scripts/lti_1s/lti_1s.py
@@ -1,8 +1,10 @@
 """
-Standalone one-step optimizer example for the controlled continuous-time LTI case.
+Standalone one-step optimizer examples for controlled LTI systems.
 
-This example owns its local data generation and training configs so it can live
-independently from the discrete-time and baseline continuous-time LTI folders.
+The folder owns its local data generation and training configs. It compares:
+
+- continuous-time: one-step only, one-step followed by weak-form refinement
+- discrete-time: one-step only, one-step followed by NODE refinement
 """
 
 import copy
@@ -14,13 +16,14 @@ import numpy as np
 import torch
 
 from dymad.io import load_model
-from dymad.models import LDM
+from dymad.models import DLDM, LDM
 from dymad.training import OneStepTrainer, StackedTrainer
 from dymad.utils import TrajectorySampler, plot_summary, plot_trajectory
 
 BASE_DIR = Path(__file__).resolve().parent
 DATA_CONFIG_PATH = BASE_DIR / "lti_1s_data.yaml"
-TRAINING_CONFIG_PATH = BASE_DIR / "lti_1s_ldm_node.yaml"
+CT_CONFIG_PATH = BASE_DIR / "lti_1s_ct.yaml"
+DT_CONFIG_PATH = BASE_DIR / "lti_1s_dt.yaml"
 DATA_PATH = BASE_DIR / "data" / "lti_1s.npz"
 
 os.chdir(BASE_DIR)
@@ -65,7 +68,7 @@ config_gau = {
     }
 }
 
-mdl_ld = {
+mdl_ct = {
     "encoder_layers": 0,
     "processor_layers": 1,
     "decoder_layers": 0,
@@ -74,6 +77,16 @@ mdl_ld = {
     "weight_init": "xavier_uniform",
     "gain": 0.01,
     "input_order": "cubic",
+}
+
+mdl_dt = {
+    "encoder_layers": 0,
+    "processor_layers": 1,
+    "decoder_layers": 0,
+    "hidden_dimension": 32,
+    "activation": "none",
+    "weight_init": "xavier_uniform",
+    "gain": 0.01,
 }
 
 trn_step = {
@@ -86,18 +99,30 @@ trn_step = {
 trn_step_warm = copy.deepcopy(trn_step)
 trn_step_warm["n_epochs"] = 1000
 
-trn_node = {
+trn_weak = {
+    "n_epochs": 1000,
+    "save_interval": 50,
+    "load_checkpoint": False,
+    "learning_rate": 5e-3,
+    "decay_rate": 0.999,
+    "weak_form_params": {
+        "N": 13,
+        "dN": 2,
+        "ordpol": 2,
+        "ordint": 2,
+    },
+}
+
+trn_dt_node = {
     "n_epochs": 1000,
     "save_interval": 50,
     "load_checkpoint": False,
     "learning_rate": 1e-3,
     "decay_rate": 0.999,
-    "sweep_lengths": [20, 40],
+    "chop_mode": "unfold",
+    "chop_step": 0.5,
+    "sweep_lengths": [3, 5, 7],
     "sweep_epoch_step": 200,
-    # "chop_mode": "unfold",
-    # "chop_step": 0.5,
-    "ode_method": "dopri5",
-    "ode_args": {"rtol": 1.0e-7, "atol": 1.0e-9},
 }
 
 
@@ -117,32 +142,61 @@ def generate_data():
 
 cases = [
     {
-        "label": "ldm_step",
-        "artifact_name": "lti_1s_ldm_step",
+        "label": "ct_step",
+        "artifact_name": "lti_1s_ct_step",
+        "config_path": CT_CONFIG_PATH,
         "model": LDM,
         "trainer": OneStepTrainer,
         "config_mod": {
-            "model": {"name": "lti_1s_ldm_step", **mdl_ld},
+            "model": {"name": "lti_1s_ct_step", **mdl_ct},
             "training": trn_step,
         },
     },
     {
-        "label": "ldm_step_node",
-        "artifact_name": "lti_1s_ldm_step_node",
+        "label": "ct_step_wf",
+        "artifact_name": "lti_1s_ct_step_wf",
+        "config_path": CT_CONFIG_PATH,
         "model": LDM,
         "trainer": StackedTrainer,
         "config_mod": {
-            "model": {"name": "lti_1s_ldm_step_node", **mdl_ld},
+            "model": {"name": "lti_1s_ct_step_wf", **mdl_ct},
             "training": None,
             "phases": [
                 _optimizer_phase("OneStep", trn_step_warm),
-                _optimizer_phase("NODE", trn_node),
+                _optimizer_phase("Weak", trn_weak),
+            ],
+        },
+    },
+    {
+        "label": "dt_step",
+        "artifact_name": "lti_1s_dt_step",
+        "config_path": DT_CONFIG_PATH,
+        "model": DLDM,
+        "trainer": OneStepTrainer,
+        "config_mod": {
+            "model": {"name": "lti_1s_dt_step", **mdl_dt},
+            "training": trn_step,
+        },
+    },
+    {
+        "label": "dt_step_node",
+        "artifact_name": "lti_1s_dt_step_node",
+        "config_path": DT_CONFIG_PATH,
+        "model": DLDM,
+        "trainer": StackedTrainer,
+        "config_mod": {
+            "model": {"name": "lti_1s_dt_step_node", **mdl_dt},
+            "training": None,
+            "phases": [
+                _optimizer_phase("OneStep", trn_step_warm),
+                _optimizer_phase("NODE", trn_dt_node),
             ],
         },
     },
 ]
 
-IDX = [0, 1]
+# IDX = [0, 1, 2, 3]
+IDX = [1]
 labels = [cases[i]["label"] for i in IDX]
 
 ifdat = 0
@@ -159,7 +213,7 @@ if iftrn:
     for i in IDX:
         case = cases[i]
         trainer = case["trainer"](
-            TRAINING_CONFIG_PATH,
+            case["config_path"],
             case["model"],
             config_mod=copy.deepcopy(case["config_mod"]),
         )
@@ -191,7 +245,7 @@ if ifprd:
     plot_trajectory(
         np.array(res),
         t_data,
-        "LTI CT",
+        "LTI",
         us=u_data,
         labels=["Truth"] + labels,
         ifclose=False,

--- a/scripts/lti_1s/lti_1s.py
+++ b/scripts/lti_1s/lti_1s.py
@@ -1,12 +1,8 @@
 """
-Continuous-time one-step nonlinear solver example for the controlled LTI case.
+Standalone one-step optimizer example for the controlled continuous-time LTI case.
 
-This expands the original one-step example in place. The `lti_dt/` location is
-historical; the comparison below now targets the continuous-time `LDM` setup so
-the missing CT workflow lives next to the original development script. The
-system and hyperparameter baseline match the existing continuous-time LTI
-examples, while keeping the same `if`-block control flow for easy regression
-checks.
+This example owns its local data generation and training configs so it can live
+independently from the discrete-time and baseline continuous-time LTI folders.
 """
 
 import copy
@@ -23,14 +19,15 @@ from dymad.training import OneStepTrainer, StackedTrainer
 from dymad.utils import TrajectorySampler, plot_summary, plot_trajectory
 
 BASE_DIR = Path(__file__).resolve().parent
-DATA_CONFIG_PATH = BASE_DIR.parent / "linear_time_invariant" / "lti_data.yaml"
-TRAINING_CONFIG_PATH = BASE_DIR.parent / "linear_time_invariant" / "lti_ldm_node.yaml"
+DATA_CONFIG_PATH = BASE_DIR / "lti_1s_data.yaml"
+TRAINING_CONFIG_PATH = BASE_DIR / "lti_1s_ldm_node.yaml"
+DATA_PATH = BASE_DIR / "data" / "lti_1s.npz"
+
 os.chdir(BASE_DIR)
 
 B = 128
 N = 501
 t_grid = np.linspace(0, 5, N)
-DATA_PATH = BASE_DIR / "data" / "lti.npz"
 
 A = np.array([[0.0, 1.0], [-1.0, -0.1]])
 
@@ -69,7 +66,6 @@ config_gau = {
 }
 
 mdl_ld = {
-    "name": "lti_ldm",
     "encoder_layers": 0,
     "processor_layers": 1,
     "decoder_layers": 0,
@@ -77,9 +73,9 @@ mdl_ld = {
     "activation": "none",
     "weight_init": "xavier_uniform",
     "gain": 0.01,
+    "input_order": "cubic",
 }
 
-# The one-step-only run is intentionally longer because it does not get a NODE refinement phase.
 trn_step = {
     "n_epochs": 1200,
     "save_interval": 20,
@@ -119,19 +115,22 @@ def generate_data():
 
 cases = [
     {
-        "name": "ldm_step",
+        "label": "ldm_step",
+        "artifact_name": "lti_1s_ldm_step",
         "model": LDM,
         "trainer": OneStepTrainer,
-        "config_mod": {"model": mdl_ld, "training": trn_step},
+        "config_mod": {
+            "model": {"name": "lti_1s_ldm_step", **mdl_ld},
+            "training": trn_step,
+        },
     },
     {
-        "name": "ldm_step_node",
+        "label": "ldm_step_node",
+        "artifact_name": "lti_1s_ldm_step_node",
         "model": LDM,
         "trainer": StackedTrainer,
         "config_mod": {
-            "model": mdl_ld,
-            # Clear the legacy single-stage block from the base YAML so it does not
-            # overwrite the explicit warm-start phase during config normalization.
+            "model": {"name": "lti_1s_ldm_step_node", **mdl_ld},
             "training": None,
             "phases": [
                 _optimizer_phase("OneStep", trn_step_warm),
@@ -142,7 +141,7 @@ cases = [
 ]
 
 IDX = [0, 1]
-labels = [cases[i]["name"] for i in IDX]
+labels = [cases[i]["label"] for i in IDX]
 
 ifdat = 0
 iftrn = 1
@@ -157,13 +156,15 @@ if iftrn:
         generate_data()
     for i in IDX:
         case = cases[i]
-        opt = copy.deepcopy(case["config_mod"])
-        opt["model"]["name"] = f"lti_{case['name']}"
-        trainer = case["trainer"](TRAINING_CONFIG_PATH, case["model"], config_mod=opt)
+        trainer = case["trainer"](
+            TRAINING_CONFIG_PATH,
+            case["model"],
+            config_mod=copy.deepcopy(case["config_mod"]),
+        )
         trainer.train()
 
 if ifplt:
-    npz_files = [f"lti_{label}" for label in labels]
+    npz_files = [cases[i]["artifact_name"] for i in IDX]
     npzs = plot_summary(npz_files, labels=labels, ifclose=False)
 
     for label, npz in zip(labels, npzs, strict=False):
@@ -180,7 +181,7 @@ if ifprd:
     res = [x_data]
     for i in IDX:
         case = cases[i]
-        _, prd_func = load_model(case["model"], f"lti_{case['name']}.pt")
+        _, prd_func = load_model(case["model"], f"{case['artifact_name']}.pt")
         with torch.no_grad():
             pred = prd_func(x_data, t_data, u=u_data)
         res.append(pred)

--- a/scripts/lti_1s/lti_1s_cli.py
+++ b/scripts/lti_1s/lti_1s_cli.py
@@ -1,14 +1,8 @@
-"""
-Standalone one-step optimizer examples for controlled LTI systems.
-
-The folder owns its local data generation and training configs. It compares:
-
-- continuous-time: one-step only, one-step followed by weak-form refinement
-- discrete-time: one-step only, one-step followed by NODE refinement
-"""
-
+import argparse
 import copy
 import os
+import random
+import shutil
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -21,12 +15,10 @@ from dymad.training import OneStepTrainer, StackedTrainer
 from dymad.utils import TrajectorySampler, plot_summary, plot_trajectory
 
 BASE_DIR = Path(__file__).resolve().parent
-DATA_CONFIG_PATH = BASE_DIR / "lti_1s_data.yaml"
-CT_CONFIG_PATH = BASE_DIR / "lti_1s_ct.yaml"
-DT_CONFIG_PATH = BASE_DIR / "lti_1s_dt.yaml"
-DATA_PATH = BASE_DIR / "data" / "lti_1s.npz"
-
-os.chdir(BASE_DIR)
+DATA_CONFIG_NAME = "lti_1s_data.yaml"
+CT_CONFIG_NAME = "lti_1s_ct.yaml"
+DT_CONFIG_NAME = "lti_1s_dt.yaml"
+DEFAULT_CASES = [0, 1, 2, 3]
 
 B = 128
 N = 501
@@ -132,19 +124,11 @@ def _optimizer_phase(trainer, cfg):
     return phase
 
 
-def generate_data():
-    sampler = TrajectorySampler(f, g, config=DATA_CONFIG_PATH, config_mod=config_chr)
-    ts, _xs, us, ys = sampler.sample(t_grid, batch=B)
-    DATA_PATH.parent.mkdir(exist_ok=True)
-    np.savez_compressed(DATA_PATH, t=ts, x=ys, u=us)
-    print(f"Generated data: {DATA_PATH}")
-
-
 cases = [
     {
         "label": "ct_step",
         "artifact_name": "lti_1s_ct_step",
-        "config_path": CT_CONFIG_PATH,
+        "config": CT_CONFIG_NAME,
         "model": LDM,
         "trainer": OneStepTrainer,
         "config_mod": {
@@ -155,7 +139,7 @@ cases = [
     {
         "label": "ct_step_wf",
         "artifact_name": "lti_1s_ct_step_wf",
-        "config_path": CT_CONFIG_PATH,
+        "config": CT_CONFIG_NAME,
         "model": LDM,
         "trainer": StackedTrainer,
         "config_mod": {
@@ -170,7 +154,7 @@ cases = [
     {
         "label": "dt_step",
         "artifact_name": "lti_1s_dt_step",
-        "config_path": DT_CONFIG_PATH,
+        "config": DT_CONFIG_NAME,
         "model": DLDM,
         "trainer": OneStepTrainer,
         "config_mod": {
@@ -181,7 +165,7 @@ cases = [
     {
         "label": "dt_step_node",
         "artifact_name": "lti_1s_dt_step_node",
-        "config_path": DT_CONFIG_PATH,
+        "config": DT_CONFIG_NAME,
         "model": DLDM,
         "trainer": StackedTrainer,
         "config_mod": {
@@ -195,45 +179,95 @@ cases = [
     },
 ]
 
-IDX = [0, 1, 2, 3]
-labels = [cases[i]["label"] for i in IDX]
 
-ifdat = 0
-iftrn = 1
-ifplt = 1
-ifprd = 1
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run LTI one-step comparison cases.")
+    parser.add_argument("--case", nargs="+", type=int, help="Case indices to run.")
+    parser.add_argument("--list-cases", action="store_true")
+    parser.add_argument("--data", action="store_true")
+    parser.add_argument("--workdir", type=Path)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--no-train", action="store_true")
+    parser.add_argument("--no-plot", action="store_true")
+    parser.add_argument("--no-predict", action="store_true")
+    parser.add_argument("--no-show", action="store_true")
+    return parser.parse_args()
 
-if ifdat:
-    generate_data()
 
-if iftrn:
-    if not DATA_PATH.exists():
-        generate_data()
-    for i in IDX:
-        case = cases[i]
+def set_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def resolve_indices(values):
+    indices = DEFAULT_CASES if values is None else values
+    invalid = [idx for idx in indices if idx < 0 or idx >= len(cases)]
+    if invalid:
+        raise ValueError(f"Invalid case indices: {invalid}")
+    return indices
+
+
+def print_cases():
+    for idx, case in enumerate(cases):
+        print(f"{idx}: {case['label']} [{case['config']}]")
+
+
+def prepare_workdir(root: Path):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "data").mkdir(exist_ok=True)
+    for name in (DATA_CONFIG_NAME, CT_CONFIG_NAME, DT_CONFIG_NAME):
+        src = BASE_DIR / name
+        dst = root / name
+        if not dst.exists():
+            shutil.copy2(src, dst)
+
+
+def generate_data(root: Path = BASE_DIR, seed: int | None = None):
+    sampler = TrajectorySampler(
+        f, g, config=root / DATA_CONFIG_NAME, rng=seed, config_mod=config_chr
+    )
+    ts, _xs, us, ys = sampler.sample(t_grid, batch=B)
+    data_path = root / "data" / "lti_1s.npz"
+    data_path.parent.mkdir(exist_ok=True)
+    np.savez_compressed(data_path, t=ts, x=ys, u=us)
+    print(f"Generated data: {data_path}")
+
+
+def train(selected, root: Path = BASE_DIR):
+    for idx in selected:
+        case = cases[idx]
         trainer = case["trainer"](
-            case["config_path"],
+            root / case["config"],
             case["model"],
             config_mod=copy.deepcopy(case["config_mod"]),
         )
         trainer.train()
 
-if ifplt:
-    npz_files = [cases[i]["artifact_name"] for i in IDX]
+
+def plot(selected):
+    labels = [cases[idx]["label"] for idx in selected]
+    npz_files = [cases[idx]["artifact_name"] for idx in selected]
     npzs = plot_summary(npz_files, labels=labels, ifclose=False)
     for label, npz in zip(labels, npzs, strict=False):
         print(f"Epoch time {label}: {npz['avg_epoch_time']}")
 
-if ifprd:
-    sampler = TrajectorySampler(f, g, config=DATA_CONFIG_PATH, config_mod=config_gau)
+
+def predict(selected, root: Path = BASE_DIR, seed: int | None = None):
+    sampler = TrajectorySampler(
+        f, g, config=root / DATA_CONFIG_NAME, rng=seed, config_mod=config_gau
+    )
     ts, xs, us, ys = sampler.sample(t_grid, batch=1)
     x_data = xs[0]
     t_data = ts[0]
     u_data = us[0]
 
     res = [x_data]
-    for i in IDX:
-        case = cases[i]
+    labels = [cases[idx]["label"] for idx in selected]
+    for idx in selected:
+        case = cases[idx]
         _, prd_func = load_model(case["model"], f"{case['artifact_name']}.pt")
         with torch.no_grad():
             pred = prd_func(x_data, t_data, u=u_data)
@@ -248,4 +282,34 @@ if ifprd:
         ifclose=False,
     )
 
-plt.show()
+
+def main():
+    args = parse_args()
+    if args.seed is not None:
+        set_seed(args.seed)
+    root = BASE_DIR if args.workdir is None else args.workdir.resolve()
+    if args.workdir is not None:
+        prepare_workdir(root)
+    os.chdir(root)
+
+    if args.list_cases:
+        print_cases()
+        return 0
+
+    selected = resolve_indices(args.case)
+    data_path = root / "data" / "lti_1s.npz"
+    if args.data or (args.workdir is not None and not data_path.exists()):
+        generate_data(root, args.seed)
+    if not args.no_train:
+        train(selected, root)
+    if not args.no_plot:
+        plot(selected)
+    if not args.no_predict:
+        predict(selected, root, args.seed)
+    if not args.no_show and (not args.no_plot or not args.no_predict):
+        plt.show()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lti_1s/lti_1s_ct.yaml
+++ b/scripts/lti_1s/lti_1s_ct.yaml
@@ -1,0 +1,45 @@
+data:
+  path: "./data/lti_1s.npz"
+  n_samples: 128
+  n_steps: 501
+  double_precision: false
+
+transform_x:
+  type: "identity"
+
+transform_u:
+  type: "identity"
+
+split:
+  train_frac: 0.75
+
+dataloader:
+  batch_size: 64
+
+model:
+  name: "lti_1s_ct_template"
+  encoder_layers: 0
+  processor_layers: 1
+  decoder_layers: 0
+  hidden_dimension: 32
+  activation: "none"
+  weight_init: "xavier_uniform"
+  input_order: "cubic"
+
+criterion:
+  dynamics:
+    weight: 1.0
+  recon:
+    weight: 1.0
+
+training:
+  n_epochs: 500
+  save_interval: 10
+  load_checkpoint: false
+  learning_rate: 5e-3
+  decay_rate: 0.999
+  weak_form_params:
+    N: 13
+    dN: 2
+    ordpol: 2
+    ordint: 2

--- a/scripts/lti_1s/lti_1s_data.yaml
+++ b/scripts/lti_1s/lti_1s_data.yaml
@@ -1,0 +1,32 @@
+# Standalone 2-state 1-input LTI data config for the one-step example.
+
+dims:
+  states: 2
+  inputs: 1
+  observations: 2
+
+control:
+  kind: sine
+  params:
+    num_components: 2
+    freq_range:
+    - 0.5
+    - 2.0
+    amp_range:
+    - 0.2
+    - 1.0
+    phase_range:
+    - 0
+    - 360
+
+x0:
+  kind: uniform
+  params:
+    bounds:
+    - -1.0
+    - 1.0
+
+solver:
+  method: RK45
+  rtol: 1.0e-6
+  atol: 1.0e-6

--- a/scripts/lti_1s/lti_1s_dt.yaml
+++ b/scripts/lti_1s/lti_1s_dt.yaml
@@ -17,24 +17,28 @@ dataloader:
   batch_size: 64
 
 model:
-  name: "lti_1s_template"
+  name: "lti_1s_dt_template"
   encoder_layers: 0
   processor_layers: 1
   decoder_layers: 0
   hidden_dimension: 32
   activation: "none"
   weight_init: "xavier_uniform"
-  input_order: "cubic"
+  gain: 0.01
+
+criterion:
+  dynamics:
+    weight: 1.0
+  recon:
+    weight: 1.0
 
 training:
-  n_epochs: 500
+  n_epochs: 1000
   save_interval: 10
   load_checkpoint: false
   learning_rate: 1e-3
   decay_rate: 0.999
-  sweep_lengths: [50, 100, 200, 300, 501]
-  sweep_epoch_step: 100
-  ode_method: "dopri5"
-  ode_args:
-    rtol: 1.0e-7
-    atol: 1.0e-9
+  chop_mode: "unfold"
+  chop_step: 0.5
+  sweep_lengths: [3, 5, 7]
+  sweep_epoch_step: 200

--- a/scripts/lti_1s/lti_1s_ldm_node.yaml
+++ b/scripts/lti_1s/lti_1s_ldm_node.yaml
@@ -1,0 +1,40 @@
+data:
+  path: "./data/lti_1s.npz"
+  n_samples: 128
+  n_steps: 501
+  double_precision: false
+
+transform_x:
+  type: "identity"
+
+transform_u:
+  type: "identity"
+
+split:
+  train_frac: 0.75
+
+dataloader:
+  batch_size: 64
+
+model:
+  name: "lti_1s_template"
+  encoder_layers: 0
+  processor_layers: 1
+  decoder_layers: 0
+  hidden_dimension: 32
+  activation: "none"
+  weight_init: "xavier_uniform"
+  input_order: "cubic"
+
+training:
+  n_epochs: 500
+  save_interval: 10
+  load_checkpoint: false
+  learning_rate: 1e-3
+  decay_rate: 0.999
+  sweep_lengths: [50, 100, 200, 300, 501]
+  sweep_epoch_step: 100
+  ode_method: "dopri5"
+  ode_args:
+    rtol: 1.0e-7
+    atol: 1.0e-9

--- a/scripts/lti_dt/lti_dt_onestep.py
+++ b/scripts/lti_dt/lti_dt_onestep.py
@@ -1,3 +1,14 @@
+"""
+Continuous-time one-step nonlinear solver example for the controlled LTI case.
+
+This expands the original one-step example in place. The `lti_dt/` location is
+historical; the comparison below now targets the continuous-time `LDM` setup so
+the missing CT workflow lives next to the original development script. The
+system and hyperparameter baseline match the existing continuous-time LTI
+examples, while keeping the same `if`-block control flow for easy regression
+checks.
+"""
+
 import copy
 import os
 from pathlib import Path
@@ -7,11 +18,13 @@ import numpy as np
 import torch
 
 from dymad.io import load_model
-from dymad.models import DLDM
+from dymad.models import LDM
 from dymad.training import OneStepTrainer, StackedTrainer
 from dymad.utils import TrajectorySampler, plot_summary, plot_trajectory
 
 BASE_DIR = Path(__file__).resolve().parent
+DATA_CONFIG_PATH = BASE_DIR.parent / "linear_time_invariant" / "lti_data.yaml"
+TRAINING_CONFIG_PATH = BASE_DIR.parent / "linear_time_invariant" / "lti_ldm_node.yaml"
 os.chdir(BASE_DIR)
 
 B = 128
@@ -56,7 +69,7 @@ config_gau = {
 }
 
 mdl_ld = {
-    "name": "lti_dldm",
+    "name": "lti_ldm",
     "encoder_layers": 0,
     "processor_layers": 1,
     "decoder_layers": 0,
@@ -83,9 +96,10 @@ trn_node = {
     "load_checkpoint": False,
     "learning_rate": 1e-3,
     "decay_rate": 0.999,
-    "chop_mode": "initial",
-    "sweep_lengths": [3, 5, 7],
-    "sweep_epoch_step": 200,
+    "sweep_lengths": [50, 100, 200, 300, 501],
+    "sweep_epoch_step": 100,
+    "ode_method": "dopri5",
+    "ode_args": {"rtol": 1.0e-7, "atol": 1.0e-9},
 }
 
 
@@ -96,7 +110,7 @@ def _optimizer_phase(trainer, cfg):
 
 
 def generate_data():
-    sampler = TrajectorySampler(f, g, config=BASE_DIR / "lti_data.yaml", config_mod=config_chr)
+    sampler = TrajectorySampler(f, g, config=DATA_CONFIG_PATH, config_mod=config_chr)
     ts, _xs, us, ys = sampler.sample(t_grid, batch=B)
     DATA_PATH.parent.mkdir(exist_ok=True)
     np.savez_compressed(DATA_PATH, t=ts, x=ys, u=us)
@@ -105,14 +119,14 @@ def generate_data():
 
 cases = [
     {
-        "name": "dldm_step",
-        "model": DLDM,
+        "name": "ldm_step",
+        "model": LDM,
         "trainer": OneStepTrainer,
         "config_mod": {"model": mdl_ld, "training": trn_step},
     },
     {
-        "name": "dldm_step_node",
-        "model": DLDM,
+        "name": "ldm_step_node",
+        "model": LDM,
         "trainer": StackedTrainer,
         "config_mod": {
             "model": mdl_ld,
@@ -145,7 +159,7 @@ if iftrn:
         case = cases[i]
         opt = copy.deepcopy(case["config_mod"])
         opt["model"]["name"] = f"lti_{case['name']}"
-        trainer = case["trainer"](BASE_DIR / "lti_dldm.yaml", case["model"], config_mod=opt)
+        trainer = case["trainer"](TRAINING_CONFIG_PATH, case["model"], config_mod=opt)
         trainer.train()
 
 if ifplt:
@@ -156,7 +170,7 @@ if ifplt:
         print(f"Epoch time {label}: {npz['avg_epoch_time']}")
 
 if ifprd:
-    sampler = TrajectorySampler(f, g, config=BASE_DIR / "lti_data.yaml", config_mod=config_gau)
+    sampler = TrajectorySampler(f, g, config=DATA_CONFIG_PATH, config_mod=config_gau)
 
     ts, xs, us, ys = sampler.sample(t_grid, batch=1)
     x_data = xs[0]
@@ -174,7 +188,7 @@ if ifprd:
     plot_trajectory(
         np.array(res),
         t_data,
-        "LTI",
+        "LTI CT",
         us=u_data,
         labels=["Truth"] + labels,
         ifclose=False,

--- a/src/dymad/agent/registry/training_schema.py
+++ b/src/dymad/agent/registry/training_schema.py
@@ -108,7 +108,7 @@ def _phase_entry_schemas() -> tuple[TrainingPhaseEntrySchema, ...]:
             summary="Legacy shorthand for one optimizer phase.",
             accepted_shape='{"trainer": "NODE" | "Weak" | "Linear" | "OneStep", ...}',
             required_fields=("trainer",),
-            optional_fields=("name",),
+            optional_fields=("name", "reset_optimizer"),
             enum_fields={"trainer": ("NODE", "Weak", "Linear", "OneStep")},
             allows_additional_keys=True,
             notes=(
@@ -122,7 +122,7 @@ def _phase_entry_schemas() -> tuple[TrainingPhaseEntrySchema, ...]:
             summary="Explicit optimizer phase.",
             accepted_shape='{"type": "optimizer", "trainer": "NODE" | "Weak" | "Linear" | "OneStep", ...}',
             required_fields=("type", "trainer"),
-            optional_fields=("name",),
+            optional_fields=("name", "reset_optimizer"),
             enum_fields={"trainer": ("NODE", "Weak", "Linear", "OneStep")},
             allows_additional_keys=True,
             notes=("Any extra keys are treated as optimizer-phase config.",),

--- a/src/dymad/training/phases.py
+++ b/src/dymad/training/phases.py
@@ -62,11 +62,20 @@ class BasePhaseSpec:
 @dataclass(frozen=True)
 class OptimizerPhaseSpec(BasePhaseSpec):
     trainer: str = "NODE"
+    reset_optimizer: bool = False
 
-    def __init__(self, name: str, trainer: str, config: dict[str, Any]):
+    def __init__(
+        self,
+        name: str,
+        trainer: str,
+        config: dict[str, Any],
+        *,
+        reset_optimizer: bool = False,
+    ):
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "kind", "optimizer")
         object.__setattr__(self, "trainer", trainer)
+        object.__setattr__(self, "reset_optimizer", reset_optimizer)
         object.__setattr__(self, "config", config)
 
 
@@ -227,10 +236,16 @@ def _optimizer_spec_from_legacy(
 ) -> OptimizerPhaseSpec:
     cfg = copy.deepcopy(entry)
     trainer = _normalize_legacy_optimizer_name(cfg.pop("trainer"))
+    reset_optimizer = bool(cfg.pop("reset_optimizer", False))
     name = cfg.get("name", f"phase_{index}")
     if suffix:
         name = f"{name}_{suffix}"
-    return OptimizerPhaseSpec(name=name, trainer=trainer, config=cfg)
+    return OptimizerPhaseSpec(
+        name=name,
+        trainer=trainer,
+        config=cfg,
+        reset_optimizer=reset_optimizer,
+    )
 
 
 def _raise_legacy_ls_update_error() -> None:
@@ -276,10 +291,11 @@ def _normalize_explicit_phase(entry: dict[str, Any], index: int) -> PhaseSpec:
         return OptimizerPhaseSpec(
             name=entry.get("name", f"phase_{index}"),
             trainer=trainer,
+            reset_optimizer=entry.get("reset_optimizer", False),
             config={
                 k: copy.deepcopy(v)
                 for k, v in entry.items()
-                if k not in {"type", "name", "trainer"}
+                if k not in {"type", "name", "trainer", "reset_optimizer"}
             },
         )
     if phase_type == "linear_solve":
@@ -711,16 +727,21 @@ class BaseOptimizerPhase(BasePhase):
         model: torch.nn.Module,
         artifacts: ArtifactRegistry,
     ) -> OptimizerStateArtifact:
-        phase_cfg = self.spec.config
+        spec = cast(OptimizerPhaseSpec, self.spec)
+        phase_cfg = spec.config
         lr = float(phase_cfg.get("learning_rate", 1e-3))
         gamma = float(phase_cfg.get("decay_rate", 0.999))
         optimizer = torch.optim.Adam(model.parameters(), lr=lr)
         prior = artifacts.get("optimizer_state")
-        if isinstance(prior, OptimizerStateArtifact):
+        if isinstance(prior, OptimizerStateArtifact) and not spec.reset_optimizer:
             try:
                 optimizer.load_state_dict(prior.optimizer.state_dict())
             except ValueError:
                 pass
+            else:
+                # Reuse moments/step counters while still honoring the new phase lr.
+                for param_group in optimizer.param_groups:
+                    param_group["lr"] = lr
         schedulers = [
             make_scheduler(torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=gamma))
         ]

--- a/tests/slow_lti_1s_cli_baselines.json
+++ b/tests/slow_lti_1s_cli_baselines.json
@@ -1,0 +1,100 @@
+{
+  "lti_1s_ct_step": {
+    "metrics": {
+      "best_valid_total": 8.789937973022461,
+      "crit_train_last": 0.00014972133794799447,
+      "crit_valid_last": 0.0007857671589590609,
+      "final_valid_loss": 8.789937973022461,
+      "rmse": 0.029494043012353907
+    },
+    "summary_signature": {
+      "best_valid_loss_keys": [
+        "epoch",
+        "train_dynamics",
+        "train_recon",
+        "train_total",
+        "valid_dynamics",
+        "valid_recon",
+        "valid_total"
+      ],
+      "crit_epoch_count": 40,
+      "crit_name": "dynamics",
+      "crit_series_count": 2,
+      "hist_count": 1,
+      "hist_entry_keys": [
+        "epoch",
+        "train_dynamics",
+        "train_recon",
+        "train_total",
+        "valid_dynamics",
+        "valid_recon",
+        "valid_total"
+      ],
+      "model_name_prefix": "lti_1s",
+      "top_level_keys": [
+        "avg_epoch_time",
+        "best_valid_loss",
+        "convergence_epoch",
+        "crit_epoch",
+        "crit_name",
+        "crits",
+        "final_train_loss",
+        "final_valid_loss",
+        "hist",
+        "model_name",
+        "phase_metrics",
+        "phase_records",
+        "total_training_time"
+      ]
+    }
+  },
+  "lti_1s_dt_step_node": {
+    "metrics": {
+      "best_valid_total": 1.1165448654537613e-07,
+      "crit_train_last": 0.00011630628432612866,
+      "crit_valid_last": 2.6480569431441836e-05,
+      "final_valid_loss": 8.29855935080559e-07,
+      "rmse": 0.02729724955296539
+    },
+    "summary_signature": {
+      "best_valid_loss_keys": [
+        "epoch",
+        "train_dynamics",
+        "train_recon",
+        "train_total",
+        "valid_dynamics",
+        "valid_recon",
+        "valid_total"
+      ],
+      "crit_epoch_count": 30,
+      "crit_name": "dynamics",
+      "crit_series_count": 2,
+      "hist_count": 2,
+      "hist_entry_keys": [
+        "epoch",
+        "train_dynamics",
+        "train_recon",
+        "train_total",
+        "valid_dynamics",
+        "valid_recon",
+        "valid_total"
+      ],
+      "model_name_prefix": "lti_1s_dt_step_node",
+      "top_level_keys": [
+        "avg_epoch_time",
+        "best_valid_loss",
+        "convergence_epoch",
+        "crit_epoch",
+        "crit_name",
+        "crits",
+        "final_train_loss",
+        "final_valid_loss",
+        "hist",
+        "model_name",
+        "phase_metrics",
+        "phase_records",
+        "total_training_time"
+      ]
+    }
+  }
+}

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -149,6 +149,9 @@ def test_describe_training_capability_exposes_phase_schema_and_override_contract
         "tie_breaker_options": ("std_metric", "param_l1", "combo_index"),
         "default_tie_breakers": ("std_metric", "combo_index"),
     }
+    phase_schemas = {entry.key: entry for entry in detail.phase_entry_schemas}
+    assert "reset_optimizer" in phase_schemas["legacy_optimizer"].optional_fields
+    assert "reset_optimizer" in phase_schemas["optimizer"].optional_fields
     assert detail.cv_schema.notes == (
         "This v1 user-mode CV surface runs the existing single-split parameter sweep; it is not "
         "true k-fold cross-validation.",

--- a/tests/test_contract_training_phase_runtime.py
+++ b/tests/test_contract_training_phase_runtime.py
@@ -213,6 +213,37 @@ def test_normalize_phase_specs_accepts_smoothing_data_phase():
     assert data_spec.config["method"] == "savgol"
 
 
+def test_normalize_phase_specs_accepts_optimizer_reset_flag():
+    specs = normalize_phase_specs(
+        {
+            "model": {"name": "demo"},
+            "phases": [
+                {
+                    "type": "optimizer",
+                    "name": "warmup",
+                    "trainer": "Weak",
+                    "reset_optimizer": True,
+                    "n_epochs": 5,
+                },
+                {
+                    "trainer": "NODE",
+                    "reset_optimizer": True,
+                    "n_epochs": 7,
+                },
+            ],
+        }
+    )
+
+    warmup = specs[0]
+    refine = specs[1]
+    assert isinstance(warmup, OptimizerPhaseSpec)
+    assert isinstance(refine, OptimizerPhaseSpec)
+    assert warmup.reset_optimizer is True
+    assert refine.reset_optimizer is True
+    assert "reset_optimizer" not in warmup.config
+    assert "reset_optimizer" not in refine.config
+
+
 def test_normalize_phase_specs_rejects_legacy_ls_update():
     with pytest.raises(
         PhaseSpecValidationError, match="'ls_update' is deprecated and no longer supported"
@@ -901,6 +932,97 @@ def test_one_step_optimizer_phase_uses_discrete_next_state_targets():
     losses = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})
 
     assert losses[0].item() == pytest.approx(2.5)
+
+
+def test_optimizer_phase_reuses_prior_state_but_honors_new_phase_lr():
+    class _SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(
+            name="weak",
+            trainer="Weak",
+            config={
+                "learning_rate": 5.0e-3,
+                "weak_form_params": {"N": 5, "dN": 1, "ordpol": 1, "ordint": 1},
+            },
+        ),
+        config=config,
+        model_class=_SimpleModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _SimpleModel()
+    prior_optimizer = torch.optim.Adam(model.parameters(), lr=1.0e-3)
+    prior_optimizer.zero_grad(set_to_none=True)
+    (model.weight.square()).backward()
+    prior_optimizer.step()
+
+    artifacts = ArtifactRegistry()
+    artifacts.put(
+        "optimizer_state",
+        OptimizerStateArtifact(
+            optimizer=prior_optimizer,
+            criteria=[],
+            criteria_weights=[],
+            criteria_names=[],
+        ),
+    )
+
+    optimizer_state = phase._build_optimizer_artifact(model, artifacts)
+
+    assert optimizer_state.optimizer.state
+    assert optimizer_state.optimizer.param_groups[0]["lr"] == pytest.approx(5.0e-3)
+
+
+def test_optimizer_phase_reset_optimizer_starts_with_fresh_state():
+    class _SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(
+            name="weak",
+            trainer="Weak",
+            config={
+                "learning_rate": 5.0e-3,
+                "weak_form_params": {"N": 5, "dN": 1, "ordpol": 1, "ordint": 1},
+            },
+            reset_optimizer=True,
+        ),
+        config=config,
+        model_class=_SimpleModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _SimpleModel()
+    prior_optimizer = torch.optim.Adam(model.parameters(), lr=1.0e-3)
+    prior_optimizer.zero_grad(set_to_none=True)
+    (model.weight.square()).backward()
+    prior_optimizer.step()
+
+    artifacts = ArtifactRegistry()
+    artifacts.put(
+        "optimizer_state",
+        OptimizerStateArtifact(
+            optimizer=prior_optimizer,
+            criteria=[],
+            criteria_weights=[],
+            criteria_names=[],
+        ),
+    )
+
+    optimizer_state = phase._build_optimizer_artifact(model, artifacts)
+
+    assert optimizer_state.optimizer.state == {}
+    assert optimizer_state.optimizer.param_groups[0]["lr"] == pytest.approx(5.0e-3)
 
 
 def test_one_step_optimizer_phase_uses_continuous_rate_targets():

--- a/tests/test_slow_lti_1s_cli.py
+++ b/tests/test_slow_lti_1s_cli.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from dymad.io import load_model
+from dymad.models import DLDM, LDM
+from dymad.utils import TrajectorySampler
+from tests.slow_regression_utils import (
+    assert_summary_against_baseline,
+    build_mpl_env,
+    compare_record_metrics,
+    extract_record,
+    load_baseline_store,
+    load_baselines,
+    load_summary,
+    write_baseline_store,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_ROOT = REPO_ROOT / "scripts" / "lti_1s"
+BASELINE_PATH = Path(__file__).with_name("slow_lti_1s_cli_baselines.json")
+TEST_SEED = 12345
+B = 128
+N = 501
+t_grid = np.linspace(0, 5, N)
+A = np.array([[0.0, 1.0], [-1.0, -0.1]])
+
+
+def f(t, x, u):
+    return (x @ A.T) + u
+
+
+def g(t, x, u):
+    return x
+
+
+CONFIG_GAU = {
+    "control": {
+        "kind": "gaussian",
+        "params": {"mean": 0.5, "std": 1.0, "t1": 4.0, "dt": 0.2, "mode": "zoh"},
+    }
+}
+
+
+@dataclass(frozen=True)
+class Case:
+    idx: int
+    model_name: str
+    model_class: type
+    seed: int = TEST_SEED
+    metric_factors: dict[str, float] = field(default_factory=dict)
+
+
+CASES = [
+    Case(0, "lti_1s_ct_step", LDM),
+    Case(3, "lti_1s_dt_step_node", DLDM),
+]
+
+
+def _eval_rmse(case: Case, checkpoint_path: Path) -> float:
+    sampler = TrajectorySampler(
+        f,
+        g,
+        config=SCRIPT_ROOT / "lti_1s_data.yaml",
+        rng=case.seed,
+        config_mod=CONFIG_GAU,
+    )
+    ts, xs, us, ys = sampler.sample(t_grid, batch=1)
+    x_data = xs[0]
+    t_data = ts[0]
+    u_data = us[0]
+    _, predict_fn = load_model(case.model_class, checkpoint_path)
+    with torch.no_grad():
+        pred = predict_fn(x_data, t_data, u=u_data)
+    return float(np.sqrt(np.mean((pred - x_data) ** 2)))
+
+
+def _run_case(case: Case, workdir: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_ROOT / "lti_1s_cli.py"),
+            "--case",
+            str(case.idx),
+            "--workdir",
+            str(workdir),
+            "--seed",
+            str(case.seed),
+            "--no-plot",
+            "--no-predict",
+            "--no-show",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        env=build_mpl_env(workdir),
+    )
+
+
+@pytest.fixture(scope="session")
+def baseline_store(request):
+    if not request.config.getoption("--record-baselines"):
+        yield None
+        return
+    store = load_baseline_store(BASELINE_PATH)
+    yield store
+    write_baseline_store(BASELINE_PATH, store)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.model_name)
+def test_lti_1s_cli(case: Case, tmp_path: Path, request, baseline_store):
+    _run_case(case, tmp_path)
+    checkpoint = tmp_path / case.model_name / f"{case.model_name}.pt"
+    summary_path = tmp_path / case.model_name / f"{case.model_name}_summary.npz"
+    assert checkpoint.exists()
+    assert summary_path.exists()
+    summary = load_summary(summary_path)
+    rmse = _eval_rmse(case, checkpoint)
+    record = extract_record(summary, rmse)
+    if request.config.getoption("--record-baselines"):
+        baseline_store[case.model_name] = record
+        return
+    baseline = load_baselines(BASELINE_PATH)[case.model_name]
+    assert_summary_against_baseline(summary, baseline)
+    compare_record_metrics(record, baseline, case.metric_factors)


### PR DESCRIPTION
Closes #41

## Summary
This PR was generated by the local AI issue worker.

## Verification
PASS make check
exit code: 0
duration: 4.91s
stdout:
ruff check .
All checks passed!
ruff format . --check
265 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 92.65s
stdout:
ript.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.ai-worktrees/issue-41/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===== 395 passed, 71 deselected, 29 warnings, 1 rerun in 88.84s (0:01:28) ======

stderr:

## Changed files
- scripts/lti_dt/lti_dt_onestep.py

## Agent notes
See diff for implementation details.
