### PR TITLE
Fix #53: Implement kernel smoothing numerics and validation

### DIFF
--- a/src/dymad/numerics/__init__.py
+++ b/src/dymad/numerics/__init__.py
@@ -2,6 +2,7 @@ from dymad.numerics.complex import complex_grid, complex_map, complex_plot, disc
 from dymad.numerics.denoising import denoise, denoising_metrics
 from dymad.numerics.dm import DM, DMF, VBDM
 from dymad.numerics.gradients import central_diff, complex_step, torch_jacobian
+from dymad.numerics.kernel_smoothing import kernel_smoothing
 from dymad.numerics.linalg import (
     check_direction,
     check_orthogonality,
@@ -49,6 +50,7 @@ __all__ = [
     "fe_step",
     "generate_coef",
     "generate_weak_weights",
+    "kernel_smoothing",
     "logm_low_rank",
     "make_random_matrix",
     "Manifold",

--- a/src/dymad/numerics/kernel_smoothing.py
+++ b/src/dymad/numerics/kernel_smoothing.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from numbers import Integral, Real
+from typing import Literal
+
+import numpy as np
+
+KernelName = Literal["gaussian", "compact_polynomial"]
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    if axis < -ndim or axis >= ndim:
+        raise ValueError(f"axis={axis} is out of bounds for an array with {ndim} dimensions.")
+    return axis % ndim
+
+
+def _validate_time(time: np.ndarray | None, *, n_samples: int) -> np.ndarray:
+    if time is None:
+        return np.arange(n_samples, dtype=np.float64)
+
+    time_array = np.asarray(time, dtype=np.float64)
+    if time_array.shape != (n_samples,):
+        raise ValueError(f"time must have shape ({n_samples},), got {time_array.shape}.")
+    if not np.isfinite(time_array).all():
+        raise ValueError("time must contain only finite values.")
+    if np.any(np.diff(time_array) <= 0):
+        raise ValueError("time must be strictly increasing.")
+    return time_array
+
+
+def _resolve_anchor_count(
+    *, n_samples: int, anchor_count: int | None, anchor_density: float | None
+) -> int:
+    if anchor_count is None and anchor_density is None:
+        anchor_density = 0.125
+    if anchor_count is not None and anchor_density is not None:
+        raise ValueError("Specify only one of anchor_count or anchor_density.")
+
+    if anchor_count is not None:
+        if not isinstance(anchor_count, Integral) or isinstance(anchor_count, bool):
+            raise ValueError("anchor_count must be a positive integer.")
+        if anchor_count < 1:
+            raise ValueError("anchor_count must be a positive integer.")
+        return int(anchor_count)
+
+    assert anchor_density is not None
+    if not isinstance(anchor_density, Real) or isinstance(anchor_density, bool):
+        raise ValueError("anchor_density must be a finite number in (0, 1].")
+    if not np.isfinite(anchor_density) or anchor_density <= 0.0 or anchor_density > 1.0:
+        raise ValueError("anchor_density must be a finite number in (0, 1].")
+    return max(1, int(np.ceil(n_samples * anchor_density)))
+
+
+def _resolve_bandwidth(
+    *,
+    time: np.ndarray,
+    anchors: np.ndarray,
+    bandwidth: float | None,
+    bandwidth_multiplier: float | None,
+) -> float:
+    if bandwidth is None and bandwidth_multiplier is None:
+        bandwidth_multiplier = 2.0
+    if bandwidth is not None and bandwidth_multiplier is not None:
+        raise ValueError("Specify only one of bandwidth or bandwidth_multiplier.")
+
+    if bandwidth is not None:
+        if not isinstance(bandwidth, Real) or isinstance(bandwidth, bool):
+            raise ValueError("bandwidth must be a positive finite number.")
+        if not np.isfinite(bandwidth) or bandwidth <= 0.0:
+            raise ValueError("bandwidth must be a positive finite number.")
+        return float(bandwidth)
+
+    if bandwidth_multiplier is None:
+        raise ValueError("Specify bandwidth or bandwidth_multiplier.")
+    if not isinstance(bandwidth_multiplier, Real) or isinstance(bandwidth_multiplier, bool):
+        raise ValueError("bandwidth_multiplier must be a positive finite number.")
+    if not np.isfinite(bandwidth_multiplier) or bandwidth_multiplier <= 0.0:
+        raise ValueError("bandwidth_multiplier must be a positive finite number.")
+
+    if anchors.size == 1:
+        spacing = float(np.mean(np.diff(time)))
+    else:
+        spacing = float(np.mean(np.diff(anchors)))
+    return float(bandwidth_multiplier) * spacing
+
+
+def _validate_degree(degree: int) -> int:
+    if not isinstance(degree, Integral) or isinstance(degree, bool) or degree < 0:
+        raise ValueError("degree must be a non-negative integer.")
+    return int(degree)
+
+
+def _validate_regularization(
+    *, ridge: float | None, rcond: float | None
+) -> tuple[float | None, float | None]:
+    if ridge is not None:
+        if not isinstance(ridge, Real) or isinstance(ridge, bool):
+            raise ValueError("ridge must be a non-negative finite number.")
+        if not np.isfinite(ridge) or ridge < 0.0:
+            raise ValueError("ridge must be a non-negative finite number.")
+        ridge = float(ridge)
+
+    if rcond is not None:
+        if not isinstance(rcond, Real) or isinstance(rcond, bool):
+            raise ValueError("rcond must be a non-negative finite number.")
+        if not np.isfinite(rcond) or rcond < 0.0:
+            raise ValueError("rcond must be a non-negative finite number.")
+        rcond = float(rcond)
+
+    return ridge, rcond
+
+
+def _build_design_matrix(
+    *,
+    time: np.ndarray,
+    kernel: KernelName,
+    anchor_count: int,
+    bandwidth: float,
+    degree: int,
+) -> np.ndarray:
+    if kernel not in {"gaussian", "compact_polynomial"}:
+        raise ValueError(
+            f"Unsupported kernel '{kernel}'. Expected 'gaussian' or 'compact_polynomial'."
+        )
+
+    anchors = np.linspace(time[0], time[-1], anchor_count, dtype=time.dtype)
+    scaled_distance = np.abs(time[:, None] - anchors[None, :]) / bandwidth
+    if kernel == "gaussian":
+        return np.exp(-0.5 * np.square(scaled_distance))
+
+    support = scaled_distance <= 1.0
+    if degree == 0:
+        return support.astype(np.float64)
+
+    basis = np.clip(1.0 - scaled_distance, a_min=0.0, a_max=None)
+    return np.where(support, basis**degree, 0.0)
+
+
+def _solve_coefficients(
+    design_matrix: np.ndarray,
+    targets: np.ndarray,
+    *,
+    ridge: float | None,
+    rcond: float | None,
+) -> np.ndarray:
+    if ridge is None or ridge == 0.0:
+        coefficients, _, _, _ = np.linalg.lstsq(design_matrix, targets, rcond=rcond)
+        return coefficients
+
+    eye = np.eye(design_matrix.shape[1], dtype=design_matrix.dtype)
+    augmented_design = np.concatenate((design_matrix, np.sqrt(ridge) * eye), axis=0)
+    augmented_targets = np.concatenate(
+        (targets, np.zeros((eye.shape[0], targets.shape[1]), dtype=targets.dtype)),
+        axis=0,
+    )
+    coefficients, _, _, _ = np.linalg.lstsq(
+        augmented_design,
+        augmented_targets,
+        rcond=rcond,
+    )
+    return coefficients
+
+
+def kernel_smoothing(
+    data: np.ndarray,
+    *,
+    kernel: KernelName = "gaussian",
+    axis: int = 0,
+    time: np.ndarray | None = None,
+    anchor_count: int | None = None,
+    anchor_density: float | None = None,
+    bandwidth: float | None = None,
+    bandwidth_multiplier: float | None = None,
+    degree: int = 3,
+    ridge: float | None = None,
+    rcond: float | None = None,
+) -> np.ndarray:
+    """Smooth data along one axis with a global kernel-basis least-squares fit."""
+    array = np.asarray(data)
+    if array.ndim == 0:
+        raise ValueError("kernel_smoothing requires an array with at least one dimension.")
+
+    _normalize_axis(axis, array.ndim)
+    moved = np.moveaxis(array, axis, 0)
+    n_samples = moved.shape[0]
+    if n_samples < 2:
+        raise ValueError("kernel_smoothing requires at least two samples along the smoothing axis.")
+
+    solve_dtype = np.result_type(moved.dtype, np.float64)
+    values = np.asarray(moved, dtype=solve_dtype)
+    if not np.isfinite(values).all():
+        raise ValueError("kernel_smoothing requires finite input values.")
+
+    degree = _validate_degree(degree)
+    ridge, rcond = _validate_regularization(ridge=ridge, rcond=rcond)
+    time_array = _validate_time(time, n_samples=n_samples)
+    resolved_anchor_count = _resolve_anchor_count(
+        n_samples=n_samples,
+        anchor_count=anchor_count,
+        anchor_density=anchor_density,
+    )
+    anchors = np.linspace(time_array[0], time_array[-1], resolved_anchor_count, dtype=np.float64)
+    resolved_bandwidth = _resolve_bandwidth(
+        time=time_array,
+        anchors=anchors,
+        bandwidth=bandwidth,
+        bandwidth_multiplier=bandwidth_multiplier,
+    )
+    design_matrix = _build_design_matrix(
+        time=time_array,
+        kernel=kernel,
+        anchor_count=resolved_anchor_count,
+        bandwidth=resolved_bandwidth,
+        degree=degree,
+    )
+
+    flattened = values.reshape(n_samples, -1)
+    coefficients = _solve_coefficients(
+        design_matrix,
+        flattened,
+        ridge=ridge,
+        rcond=rcond,
+    )
+    smoothed = (design_matrix @ coefficients).reshape(values.shape)
+
+    result = np.moveaxis(smoothed, 0, axis)
+    if np.issubdtype(array.dtype, np.floating) or np.issubdtype(array.dtype, np.complexfloating):
+        return np.asarray(result, dtype=array.dtype)
+    return result

--- a/tests/test_assert_denoising.py
+++ b/tests/test_assert_denoising.py
@@ -4,6 +4,7 @@ import torch
 from scipy.signal import savgol_filter
 
 from dymad.numerics import denoise, denoising_metrics
+from dymad.numerics.kernel_smoothing import kernel_smoothing
 
 
 def test_denoise_savgol_matches_scipy_for_numpy_arrays():
@@ -101,3 +102,177 @@ def test_denoising_metrics_aggregate_multiple_signals():
 def test_denoise_rejects_unknown_method():
     with pytest.raises(ValueError, match="Unsupported denoising method"):
         denoise(np.ones((9, 2)), method="median")
+
+
+def _kernel_basis(
+    time: np.ndarray,
+    *,
+    kernel: str,
+    anchor_count: int,
+    bandwidth: float,
+    degree: int,
+) -> np.ndarray:
+    anchors = np.linspace(time[0], time[-1], anchor_count, dtype=np.float64)
+    scaled_distance = np.abs(time[:, None] - anchors[None, :]) / bandwidth
+    if kernel == "gaussian":
+        return np.exp(-0.5 * np.square(scaled_distance))
+
+    support = scaled_distance <= 1.0
+    if degree == 0:
+        return support.astype(np.float64)
+
+    basis = np.clip(1.0 - scaled_distance, a_min=0.0, a_max=None)
+    return np.where(support, basis**degree, 0.0)
+
+
+def test_kernel_smoothing_matches_global_lstsq_on_flattened_targets():
+    time = np.array([0.0, 0.2, 0.45, 0.9, 1.4, 2.0], dtype=np.float64)
+    base = np.stack(
+        (
+            np.sin(time),
+            np.cos(time),
+        ),
+        axis=1,
+    )
+    data = np.stack((base, base + np.array([0.3, -0.1])), axis=0)
+
+    result = kernel_smoothing(
+        data,
+        axis=1,
+        time=time,
+        kernel="gaussian",
+        anchor_count=3,
+        bandwidth=0.7,
+        rcond=1e-10,
+    )
+
+    moved = np.moveaxis(data, 1, 0)
+    design = _kernel_basis(time, kernel="gaussian", anchor_count=3, bandwidth=0.7, degree=3)
+    expected_flat, _, _, _ = np.linalg.lstsq(design, moved.reshape(len(time), -1), rcond=1e-10)
+    expected = (design @ expected_flat).reshape(moved.shape)
+    expected = np.moveaxis(expected, 0, 1)
+
+    assert result.shape == data.shape
+    np.testing.assert_allclose(result, expected)
+
+
+def test_kernel_smoothing_supports_compact_polynomial_kernel_and_negative_axis():
+    time = np.array([0.0, 0.15, 0.5, 1.1, 1.8], dtype=np.float64)
+    data = np.array(
+        [
+            [[0.0, 1.0, 0.5, -0.5, -1.0], [1.0, 0.0, 0.5, 1.0, 0.0]],
+            [[0.2, 1.2, 0.7, -0.2, -0.8], [0.8, 0.1, 0.4, 1.1, 0.2]],
+        ],
+        dtype=np.float64,
+    )
+
+    result = kernel_smoothing(
+        data,
+        axis=-1,
+        time=time,
+        kernel="compact_polynomial",
+        anchor_count=4,
+        bandwidth=0.9,
+        degree=2,
+    )
+
+    design = _kernel_basis(
+        time,
+        kernel="compact_polynomial",
+        anchor_count=4,
+        bandwidth=0.9,
+        degree=2,
+    )
+    moved = np.moveaxis(data, -1, 0)
+    expected_flat, _, _, _ = np.linalg.lstsq(design, moved.reshape(len(time), -1), rcond=None)
+    expected = (design @ expected_flat).reshape(moved.shape)
+    expected = np.moveaxis(expected, 0, -1)
+
+    assert result.shape == data.shape
+    np.testing.assert_allclose(result, expected)
+
+
+def test_kernel_smoothing_preserves_compact_support_for_zero_degree():
+    time = np.array([0.0, 1.0, 2.0], dtype=np.float64)
+    data = np.array([1.0, 999.0, 2.0], dtype=np.float64)
+
+    result = kernel_smoothing(
+        data,
+        time=time,
+        kernel="compact_polynomial",
+        anchor_count=2,
+        bandwidth=0.75,
+        degree=0,
+    )
+
+    expected_design = np.array(
+        [
+            [1.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    expected_coefficients, _, _, _ = np.linalg.lstsq(
+        expected_design,
+        data[:, None],
+        rcond=None,
+    )
+    expected = (expected_design @ expected_coefficients).ravel()
+
+    np.testing.assert_allclose(result, expected)
+
+
+def test_kernel_smoothing_default_bandwidth_scales_with_time_for_single_anchor():
+    time = np.array([0.0, 0.25, 0.6, 1.0, 1.55, 2.1, 2.8, 3.7], dtype=np.float64)
+    data = np.stack((np.sin(time), np.cos(time)), axis=1)
+
+    baseline = kernel_smoothing(data, time=time, kernel="gaussian")
+    scaled = kernel_smoothing(data, time=time * 100.0, kernel="gaussian")
+
+    np.testing.assert_allclose(scaled, baseline)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"axis": -3}, "out of bounds"),
+        ({"anchor_count": 2, "anchor_density": 0.5}, "Specify only one"),
+        ({"bandwidth": 1.0, "bandwidth_multiplier": 2.0, "anchor_count": 2}, "Specify only one"),
+        ({"kernel": "epanechnikov", "anchor_count": 2, "bandwidth": 1.0}, "Unsupported kernel"),
+        ({"anchor_density": 0.0}, "anchor_density"),
+        ({"anchor_count": 0}, "anchor_count"),
+        ({"degree": -1}, "degree"),
+        ({"ridge": -1.0}, "ridge"),
+        ({"rcond": -1.0}, "rcond"),
+    ],
+)
+def test_kernel_smoothing_rejects_invalid_hyperparameters(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        kernel_smoothing(np.ones((6, 2)), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("time", "match"),
+    [
+        (np.array([0.0, 0.5, 1.0]), "shape"),
+        (np.array([0.0, 0.5, 0.5, 1.0, 1.5, 2.0]), "strictly increasing"),
+        (np.array([0.0, 0.5, np.nan, 1.0, 1.5, 2.0]), "finite"),
+    ],
+)
+def test_kernel_smoothing_rejects_invalid_time(time, match):
+    with pytest.raises(ValueError, match=match):
+        kernel_smoothing(np.ones((6, 2)), time=time)
+
+
+def test_kernel_smoothing_rejects_non_finite_input_values():
+    data = np.ones((6, 2))
+    data[2, 1] = np.inf
+
+    with pytest.raises(ValueError, match="finite input values"):
+        kernel_smoothing(data)
+
+
+def test_kernel_smoothing_rejects_length_one_axis():
+    with pytest.raises(ValueError, match="at least two samples"):
+        kernel_smoothing(np.ones((1, 3)))


### PR DESCRIPTION
Closes #53

## Summary
This PR was generated by the local AI issue worker.

## Verification
PASS make check
exit code: 0
duration: 4.70s
stdout:
ruff check .
All checks passed!
ruff format . --check
271 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 96.61s
stdout:
ript.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.ai-worktrees/issue-53/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 419 passed, 76 deselected, 29 warnings in 92.77s (0:01:32) ==========

stderr:

## Changed files
- src/dymad/numerics/__init__.py
- src/dymad/numerics/kernel_smoothing.py
- tests/test_assert_denoising.py

## Agent notes
See diff for implementation details.
