### PR TITLE
Fix #57: Implement kernel smoothing denoising in DyMAD

### DIFF
--- a/src/dymad/numerics/denoising.py
+++ b/src/dymad/numerics/denoising.py
@@ -1,22 +1,216 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal, TypeAlias, overload
+from typing import Literal, SupportsFloat, TypeAlias, overload
 
 import numpy as np
 import torch
 from scipy.signal import savgol_filter
 
 ArrayLike: TypeAlias = np.ndarray | torch.Tensor
-DenoiseMethod = Literal["savgol"]
+DenoiseMethod = Literal["savgol", "kernel_smoothing"]
+KernelName = Literal["gaussian", "compact_polynomial"]
 
 
 def _denoise_savgol(data: ArrayLike, *, axis: int, **kwargs) -> ArrayLike:
     array = _to_numpy(data)
     smoothed = savgol_filter(array, axis=axis, **kwargs)
-    if isinstance(data, torch.Tensor):
-        return torch.as_tensor(smoothed, device=data.device, dtype=data.dtype)
-    return np.asarray(smoothed, dtype=data.dtype)
+    return _from_numpy(np.asarray(smoothed), like=data)
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    if not -ndim <= axis < ndim:
+        raise ValueError(f"Invalid axis {axis} for array with {ndim} dimensions.")
+    return axis % ndim
+
+
+def _from_numpy(array: np.ndarray, *, like: ArrayLike) -> ArrayLike:
+    if isinstance(like, torch.Tensor):
+        return torch.as_tensor(array, device=like.device, dtype=like.dtype)
+    return np.asarray(array, dtype=like.dtype)
+
+
+def _validate_finite(name: str, array: np.ndarray) -> None:
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+
+
+def _coerce_positive_scalar(
+    name: str,
+    value: SupportsFloat,
+    *,
+    integer: bool = False,
+    allow_zero: bool = False,
+) -> int | float:
+    scalar = float(value)
+    lower_bound = 0.0 if allow_zero else 0.0
+    if not np.isfinite(scalar) or scalar < lower_bound or (not allow_zero and scalar == 0.0):
+        qualifier = "nonnegative" if allow_zero else "positive"
+        raise ValueError(f"{name} must be {qualifier}.")
+    if integer:
+        if not scalar.is_integer():
+            raise ValueError(f"{name} must be an integer.")
+        return int(scalar)
+    return scalar
+
+
+def _resolve_time(time: Sequence[float] | np.ndarray | None, *, n_samples: int) -> np.ndarray:
+    if time is None:
+        return np.linspace(0.0, 1.0, n_samples, dtype=np.float64)
+
+    grid = np.asarray(time, dtype=np.float64)
+    if grid.ndim != 1:
+        raise ValueError("time must be a 1D array.")
+    if grid.shape[0] != n_samples:
+        raise ValueError("time must have the same length as the denoising axis.")
+    _validate_finite("time", grid)
+    if np.any(np.diff(grid) <= 0.0):
+        raise ValueError("time must be strictly increasing.")
+    return grid
+
+
+def _resolve_anchor_count(
+    time: np.ndarray,
+    *,
+    anchor_count: int | float | None,
+    anchor_density: float | None,
+) -> int:
+    if anchor_count is not None:
+        count = int(_coerce_positive_scalar("anchor_count", anchor_count, integer=True))
+    elif anchor_density is not None:
+        density = float(_coerce_positive_scalar("anchor_density", anchor_density))
+        span = float(time[-1] - time[0])
+        count = int(np.ceil(density * span))
+    else:
+        raise ValueError(
+            "kernel_smoothing requires anchor_count or anchor_density to produce at least one anchor."
+        )
+
+    if count < 1:
+        raise ValueError("kernel_smoothing anchor configuration must produce at least one anchor.")
+    return count
+
+
+def _resolve_bandwidth(
+    time: np.ndarray,
+    *,
+    anchor_count: int,
+    bandwidth: float | None,
+    bandwidth_multiplier: float | None,
+) -> float:
+    if bandwidth is not None:
+        return float(_coerce_positive_scalar("bandwidth", bandwidth))
+
+    multiplier = 2.0 if bandwidth_multiplier is None else bandwidth_multiplier
+    multiplier = float(_coerce_positive_scalar("bandwidth_multiplier", multiplier))
+    span = float(time[-1] - time[0])
+    spacing = span if anchor_count == 1 else span / float(anchor_count - 1)
+    return multiplier * spacing
+
+
+def _build_kernel_design_matrix(
+    time: np.ndarray,
+    anchors: np.ndarray,
+    *,
+    kernel: KernelName | str,
+    bandwidth: float,
+    degree: float = 4.0,
+) -> np.ndarray:
+    kernel_name = str(kernel)
+    degree_value = float(_coerce_positive_scalar("degree", degree))
+    bandwidth_value = float(_coerce_positive_scalar("bandwidth", bandwidth))
+    scaled = (time[:, None] - anchors[None, :]) / bandwidth_value
+
+    if kernel_name == "gaussian":
+        return np.exp(-0.5 * np.square(scaled))
+    if kernel_name == "compact_polynomial":
+        return np.power(np.maximum(1.0 - np.square(scaled), 0.0), degree_value)
+    raise ValueError(f"Unsupported kernel '{kernel_name}'.")
+
+
+def _solve_least_squares(
+    design: np.ndarray,
+    response: np.ndarray,
+    *,
+    ridge: float = 0.0,
+    rcond: float | None = None,
+) -> np.ndarray:
+    ridge_value = float(_coerce_positive_scalar("ridge", ridge, allow_zero=True))
+    effective_rcond = None
+    if rcond is not None:
+        effective_rcond = float(_coerce_positive_scalar("rcond", rcond, allow_zero=True))
+
+    if ridge_value > 0.0:
+        regularizer = np.sqrt(ridge_value) * np.eye(design.shape[1], dtype=np.float64)
+        system_matrix = np.vstack((design, regularizer))
+        system_rhs = np.vstack((response, np.zeros((design.shape[1], response.shape[1]))))
+    else:
+        system_matrix = design
+        system_rhs = response
+
+    try:
+        coefficients, _residuals, rank, _singular_values = np.linalg.lstsq(
+            system_matrix,
+            system_rhs,
+            rcond=effective_rcond,
+        )
+        if rank == system_matrix.shape[1]:
+            return coefficients
+    except np.linalg.LinAlgError:
+        pass
+
+    pinv_rcond = 1e-15 if effective_rcond is None else effective_rcond
+    return np.linalg.pinv(system_matrix, rcond=pinv_rcond) @ system_rhs
+
+
+def _denoise_kernel_smoothing(
+    data: ArrayLike,
+    *,
+    axis: int,
+    kernel: KernelName | str = "gaussian",
+    anchor_count: int | float | None = None,
+    anchor_density: float | None = None,
+    bandwidth: float | None = None,
+    bandwidth_multiplier: float | None = None,
+    degree: float = 4.0,
+    ridge: float = 0.0,
+    rcond: float | None = None,
+    time: Sequence[float] | np.ndarray | None = None,
+) -> ArrayLike:
+    original = _to_numpy(data)
+    normalized_axis = _normalize_axis(axis, original.ndim)
+    leading = np.moveaxis(original, normalized_axis, 0)
+    n_samples = int(leading.shape[0])
+    if n_samples < 2:
+        raise ValueError("kernel_smoothing requires at least 2 samples along the denoising axis.")
+
+    flat = leading.reshape(n_samples, -1).astype(np.float64, copy=False)
+    _validate_finite("data", flat)
+
+    sample_time = _resolve_time(time, n_samples=n_samples)
+    count = _resolve_anchor_count(
+        sample_time,
+        anchor_count=anchor_count,
+        anchor_density=anchor_density,
+    )
+    anchors = np.linspace(sample_time[0], sample_time[-1], count, dtype=np.float64)
+    kernel_bandwidth = _resolve_bandwidth(
+        sample_time,
+        anchor_count=count,
+        bandwidth=bandwidth,
+        bandwidth_multiplier=bandwidth_multiplier,
+    )
+    design = _build_kernel_design_matrix(
+        sample_time,
+        anchors,
+        kernel=kernel,
+        bandwidth=kernel_bandwidth,
+        degree=degree,
+    )
+    coefficients = _solve_least_squares(design, flat, ridge=ridge, rcond=rcond)
+    smoothed = (design @ coefficients).reshape(leading.shape)
+    restored = np.moveaxis(smoothed, 0, normalized_axis)
+    return _from_numpy(restored, like=data)
 
 
 def _to_numpy(data: ArrayLike) -> np.ndarray:
@@ -39,6 +233,8 @@ def denoise(data: ArrayLike, *, method: str = "savgol", axis: int = 0, **kwargs)
     """Apply a model-independent denoising method while preserving the input array type."""
     if method == "savgol":
         return _denoise_savgol(data, axis=axis, **kwargs)
+    if method == "kernel_smoothing":
+        return _denoise_kernel_smoothing(data, axis=axis, **kwargs)
     raise ValueError(f"Unsupported denoising method '{method}'.")
 
 

--- a/tests/test_assert_denoising.py
+++ b/tests/test_assert_denoising.py
@@ -4,6 +4,7 @@ import torch
 from scipy.signal import savgol_filter
 
 from dymad.numerics import denoise, denoising_metrics
+from dymad.numerics.denoising import _build_kernel_design_matrix
 
 
 def test_denoise_savgol_matches_scipy_for_numpy_arrays():
@@ -60,6 +61,231 @@ def test_denoise_savgol_requires_window_length_and_polyorder():
 
     with pytest.raises(TypeError, match="polyorder"):
         denoise(np.ones((9, 2)), method="savgol", window_length=5)
+
+
+@pytest.mark.parametrize(
+    ("kernel", "degree", "expected"),
+    [
+        (
+            "gaussian",
+            4.0,
+            np.exp(
+                -0.5
+                * np.square(
+                    (np.array([0.0, 0.5, 1.0])[:, None] - np.array([0.0, 1.0])[None, :]) / 0.5
+                )
+            ),
+        ),
+        (
+            "compact_polynomial",
+            2.0,
+            np.power(
+                np.maximum(
+                    1.0
+                    - np.square(
+                        (np.array([0.0, 0.5, 1.0])[:, None] - np.array([0.0, 1.0])[None, :]) / 0.75
+                    ),
+                    0.0,
+                ),
+                2.0,
+            ),
+        ),
+    ],
+)
+def test_kernel_smoothing_design_matrix_matches_closed_forms(
+    kernel: str,
+    degree: float,
+    expected: np.ndarray,
+) -> None:
+    time = np.array([0.0, 0.5, 1.0], dtype=np.float64)
+    anchors = np.array([0.0, 1.0], dtype=np.float64)
+    bandwidth = 0.5 if kernel == "gaussian" else 0.75
+
+    actual = _build_kernel_design_matrix(
+        time,
+        anchors,
+        kernel=kernel,
+        bandwidth=bandwidth,
+        degree=degree,
+    )
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_denoise_kernel_smoothing_preserves_shape_and_handles_negative_axis() -> None:
+    base = np.linspace(0.0, 1.0, 7)
+    data = np.stack(
+        [
+            np.stack((base, np.sin(base * np.pi)), axis=1),
+            np.stack((base**2, np.cos(base * np.pi)), axis=1),
+            np.stack((np.sqrt(base + 1.0), np.sin(base * 2.0 * np.pi)), axis=1),
+        ],
+        axis=0,
+    )
+
+    actual = denoise(
+        data,
+        method="kernel_smoothing",
+        axis=-2,
+        kernel="gaussian",
+        anchor_count=5,
+        bandwidth_multiplier=1.5,
+    )
+    expected = np.stack(
+        [
+            denoise(
+                trajectory,
+                method="kernel_smoothing",
+                axis=0,
+                kernel="gaussian",
+                anchor_count=5,
+                bandwidth_multiplier=1.5,
+            )
+            for trajectory in data
+        ],
+        axis=0,
+    )
+
+    assert actual.shape == data.shape
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_denoise_kernel_smoothing_preserves_torch_dtype_and_device() -> None:
+    time = np.linspace(0.0, 1.0, 9, dtype=np.float64)
+    data = torch.stack(
+        (
+            torch.linspace(0.0, 1.0, 9, dtype=torch.float32),
+            torch.cos(torch.linspace(0.0, np.pi, 9, dtype=torch.float32)),
+        ),
+        dim=1,
+    )
+
+    result = denoise(
+        data,
+        method="kernel_smoothing",
+        kernel="compact_polynomial",
+        anchor_count=6,
+        bandwidth_multiplier=2.0,
+        degree=4,
+        time=time,
+    )
+
+    assert isinstance(result, torch.Tensor)
+    assert result.dtype is data.dtype
+    assert result.device == data.device
+    np.testing.assert_allclose(
+        result.detach().cpu().numpy(),
+        denoise(
+            data.detach().cpu().numpy(),
+            method="kernel_smoothing",
+            kernel="compact_polynomial",
+            anchor_count=6,
+            bandwidth_multiplier=2.0,
+            degree=4,
+            time=time,
+        ).astype(np.float32),
+        atol=1e-6,
+        rtol=1e-6,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (
+            {"kernel": "triangle", "anchor_count": 3, "bandwidth_multiplier": 1.0},
+            "Unsupported kernel",
+        ),
+        (
+            {"axis": 2, "anchor_count": 3, "bandwidth_multiplier": 1.0},
+            "Invalid axis",
+        ),
+        (
+            {"anchor_count": 3, "bandwidth": 0.0},
+            "bandwidth must be positive",
+        ),
+        (
+            {"anchor_count": 3, "bandwidth_multiplier": 0.0},
+            "bandwidth_multiplier must be positive",
+        ),
+        (
+            {
+                "kernel": "compact_polynomial",
+                "anchor_count": 3,
+                "bandwidth_multiplier": 1.0,
+                "degree": 0.0,
+            },
+            "degree must be positive",
+        ),
+        (
+            {"bandwidth_multiplier": 1.0},
+            "anchor_count or anchor_density",
+        ),
+        (
+            {"anchor_count": 3, "bandwidth_multiplier": 1.0, "time": np.ones((5, 1))},
+            "time must be a 1D array",
+        ),
+        (
+            {"anchor_count": 3, "bandwidth_multiplier": 1.0, "time": np.ones(4)},
+            "same length",
+        ),
+        (
+            {
+                "anchor_count": 3,
+                "bandwidth_multiplier": 1.0,
+                "time": np.array([0.0, 0.2, 0.2, 0.7, 1.0]),
+            },
+            "strictly increasing",
+        ),
+    ],
+)
+def test_denoise_kernel_smoothing_rejects_invalid_configuration(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    data = np.ones((5, 2), dtype=np.float64)
+
+    with pytest.raises(ValueError, match=match):
+        denoise(data, method="kernel_smoothing", **kwargs)
+
+
+def test_denoise_kernel_smoothing_rejects_short_and_nonfinite_inputs() -> None:
+    with pytest.raises(ValueError, match="at least 2 samples"):
+        denoise(
+            np.ones((1, 2), dtype=np.float64),
+            method="kernel_smoothing",
+            anchor_count=1,
+            bandwidth_multiplier=1.0,
+        )
+
+    with pytest.raises(ValueError, match="finite"):
+        denoise(
+            np.array([[0.0], [np.nan]], dtype=np.float64),
+            method="kernel_smoothing",
+            anchor_count=2,
+            bandwidth_multiplier=1.0,
+        )
+
+
+def test_denoise_kernel_smoothing_improves_rmse_on_noisy_signal() -> None:
+    rng = np.random.default_rng(12)
+    time = np.linspace(0.0, 4.0 * np.pi, 128, dtype=np.float64)
+    clean = np.stack((np.sin(time), np.cos(0.5 * time)), axis=1)
+    noisy = clean + rng.normal(scale=0.35, size=clean.shape)
+
+    smoothed = denoise(
+        noisy,
+        method="kernel_smoothing",
+        kernel="gaussian",
+        anchor_count=32,
+        bandwidth_multiplier=2.0,
+        time=time,
+    )
+
+    noisy_rmse = float(np.sqrt(np.mean(np.square(noisy - clean))))
+    smoothed_rmse = float(np.sqrt(np.mean(np.square(smoothed - clean))))
+
+    assert smoothed_rmse < noisy_rmse
 
 
 def test_denoising_metrics_aggregate_multiple_signals():

--- a/tests/test_assert_di.py
+++ b/tests/test_assert_di.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.signal import savgol_filter
 
 from dymad.io import DataInterface
+from dymad.numerics import denoise
 
 
 def train_case(data, sample, path):
@@ -49,6 +50,42 @@ def test_di_encode_applies_denoise_per_trajectory_for_batched_inputs(kp_data, en
 
     actual = di.encode(x_batch)
     expected = savgol_filter(x_batch, window_length=5, polyorder=2, axis=1)
+
+    np.testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(di.decode(actual), actual, atol=1e-6, rtol=1e-6)
+
+
+def test_di_encode_supports_kernel_smoothing_per_trajectory(kp_data, env_setup):
+    x_batch = np.load(kp_data)["x"]
+    config_path = env_setup / "ker_model_auto.yaml"
+    config_mod = {
+        "data": {"path": kp_data},
+        "transform_x": [
+            {
+                "type": "denoise",
+                "method": "kernel_smoothing",
+                "kernel": "gaussian",
+                "anchor_count": 8,
+                "bandwidth_multiplier": 2.0,
+            }
+        ],
+    }
+    di = DataInterface(config_path=config_path, config_mod=config_mod)
+
+    actual = di.encode(x_batch)
+    expected = np.stack(
+        [
+            denoise(
+                trajectory,
+                method="kernel_smoothing",
+                kernel="gaussian",
+                anchor_count=8,
+                bandwidth_multiplier=2.0,
+            )
+            for trajectory in x_batch
+        ],
+        axis=0,
+    )
 
     np.testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)
     np.testing.assert_allclose(di.decode(actual), actual, atol=1e-6, rtol=1e-6)

--- a/tests/test_contract_transform_builder.py
+++ b/tests/test_contract_transform_builder.py
@@ -69,7 +69,33 @@ def test_build_transform_module_wraps_external_transforms(config, module_type, r
     np.testing.assert_allclose(recovered, reference_inverse, rtol=rtol, atol=rtol)
 
 
-def test_build_transform_module_supports_denoise_config_and_state_reload() -> None:
+@pytest.mark.parametrize(
+    ("config", "expected_kwargs"),
+    [
+        (
+            {"type": "Denoise", "method": "savgol", "window_length": 5, "polyorder": 2},
+            {"window_length": 5, "polyorder": 2},
+        ),
+        (
+            {
+                "type": "Denoise",
+                "method": "kernel_smoothing",
+                "kernel": "gaussian",
+                "anchor_count": 4,
+                "bandwidth_multiplier": 2.0,
+            },
+            {
+                "kernel": "gaussian",
+                "anchor_count": 4,
+                "bandwidth_multiplier": 2.0,
+            },
+        ),
+    ],
+)
+def test_build_transform_module_supports_denoise_config_and_state_reload(
+    config: dict[str, object],
+    expected_kwargs: dict[str, object],
+) -> None:
     payload = np.array(
         [
             [0.0, 0.1],
@@ -80,7 +106,6 @@ def test_build_transform_module_supports_denoise_config_and_state_reload() -> No
         ],
         dtype=np.float32,
     )
-    config = {"type": "Denoise", "method": "savgol", "window_length": 5, "polyorder": 2}
 
     module = build_transform_module(config)
     module.fit([torch.as_tensor(payload)])
@@ -89,8 +114,8 @@ def test_build_transform_module_supports_denoise_config_and_state_reload() -> No
 
     assert isinstance(module.transforms[0], DenoisingTransform)
     assert isinstance(reloaded.transforms[0], DenoisingTransform)
-    assert state["children"][0]["method"] == "savgol"
-    assert state["children"][0]["kwargs"] == {"window_length": 5, "polyorder": 2}
+    assert state["children"][0]["method"] == config["method"]
+    assert state["children"][0]["kwargs"] == expected_kwargs
 
     actual = reloaded.transform_batch([torch.as_tensor(payload)])[0]
     expected = module.transform_batch([torch.as_tensor(payload)])[0]


### PR DESCRIPTION
Closes #57

## Summary
This PR was generated by the local AI issue worker.

## Verification
PASS make check
exit code: 0
duration: 4.62s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 93.09s
stdout:
ript.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.ai-worktrees/issue-57/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 418 passed, 76 deselected, 29 warnings in 90.05s (0:01:30) ==========

stderr:

## Changed files
- src/dymad/numerics/denoising.py
- tests/test_assert_denoising.py
- tests/test_assert_di.py
- tests/test_contract_transform_builder.py

## Agent notes
See diff for implementation details.
