### PR TITLE
Fix #59: test issue for a-dev: remove variable-length data bullet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ If there are API errors such as some files not found, try deleting the auto-gene
 
 # TODO notes
 
-- Variable length data (Data class does allow this, but collate and training need to adapt)
 - Update the aircraft example
 - Update the double pendulum example
 


### PR DESCRIPTION
Closes #59

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 5.14s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 97.86s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-59/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 421 passed, 76 deselected, 29 warnings in 93.96s (0:01:33) ==========

stderr:

## Changed files
- README.md

## Agent notes
See diff for implementation details.
