### PR TITLE
Fix #63: Refresh `examples/double_pendulum` notebooks for the current API/config

### DIFF
--- a/examples/double_pendulum/README.md
+++ b/examples/double_pendulum/README.md
@@ -1,115 +1,28 @@
-# Double Pendulum: Unified LDM Training Comparison
+# Double Pendulum
 
-This directory demonstrates training the same **Latent Dynamics Model (LDM)** architecture using two different training approaches:
+This directory contains the supported double-pendulum example surface:
 
-1. **NODE Training** - Direct ODE integration loss (more accurate, slower)
-2. **Weak Form Training** - Weak form loss (faster, approximate)
+- `double_pendulum_train.py`: script entrypoint for the full training configs.
+- `dp_ldm_node.yaml`, `dp_ldm_wf.yaml`, `dp_kbf_node.yaml`, `dp_kbf_wf.yaml`: tracked training configs for LDM/KBF with NODE or weak-form training.
+- `double_pendulum_data.yaml`: data-generation config used by the script and by any local notebook runs.
+- `deprecated/`: historical material only; it is not the supported entrypoint.
 
-## Files
-
-### Training Scripts
-- `train_ldm_node.py` - Train LDM with NODE approach (direct ODE integration)
-- `train_ldm_weak_form.py` - Train LDM with weak form approach  
-- `compare_training_approaches.py` - **Compare both methods side-by-side**
-
-### Configuration Files
-- `config_ldm_node.yaml` - NODE-specific configuration
-- `config_ldm_weak_form.yaml` - Weak form-specific configuration
-- `config_training_compare.yaml` - Configuration for comparison script
+The tracked configs now use explicit `phases` entries and pin `data.split_seed` so the train/validation split is reproducible.
 
 ## Quick Start
 
-### 1. Compare Both Training Methods 
+Script:
+
 ```bash
 cd examples/double_pendulum
-python compare_training_approaches.py
+python double_pendulum_train.py
 ```
 
-This will:
-- Train the same LDM model with both approaches for **1000 epochs**
-- Monitor progress every **10 epochs** with live plot updates
-- Compare training time, accuracy, and predictions
-- Generate comprehensive comparison plots and data export
+`double_pendulum_train.py` selects one of the tracked configs through the `case` index:
 
-**Output Files:**
-- `training_comparison.log` - Complete training logs
-- `training_comparison.png` - Prediction comparison plot
-- `training_history_comparison.png` - Loss evolution and timing plots
-- `training_history_comparison.csv` - Complete training metrics data
+- `0`: `LDM` with `NODETrainer` using `dp_ldm_node.yaml`
+- `1`: `LDM` with `WeakFormTrainer` using `dp_ldm_wf.yaml`
+- `2`: `KBF` with `NODETrainer` using `dp_kbf_node.yaml`
+- `3`: `KBF` with `WeakFormTrainer` using `dp_kbf_wf.yaml`
 
-### 2. Train Individual Models
-
-**NODE Training:**
-```bash
-python train_ldm_node.py
-```
-Uses `config_ldm_node.yaml`
-
-**Weak Form Training:**
-```bash
-python train_ldm_weak_form.py
-```
-Uses `config_ldm_weak_form.yaml`
-
-## Architecture
-
-Both training scripts use the **same unified LDM model** but with different trainers:
-
-- **NODETrainer**: Inherits from `TrainerBase`, uses direct ODE integration loss
-- **WeakFormTrainer**: Inherits from `TrainerBase`, uses weak form loss
-- **LDM Model**: Unified architecture with encoder, dynamics, and decoder networks
-
-The `TrainerBase` class handles:
-- Configuration loading
-- Data setup and trajectory management
-- Model initialization
-- Training loop and checkpointing
-- Evaluation and logging
-
-## Comparison Features
-
-The comparison script provides:
-
-### Real-time Monitoring
-- **Live plot updates** every 10 epochs during training
-- **Normalized loss comparison** for fair evaluation
-- **Per-epoch timing** measurements
-- **Convergence analysis** with threshold tracking
-
-### Comprehensive Analysis
-- **Training efficiency**: Total time, per-epoch time, convergence speed
-- **Final accuracy**: Test loss, RMSE, prediction quality
-- **Convergence patterns**: When each method reaches accuracy thresholds
-- **Visual comparison**: Side-by-side prediction plots
-
-### Data Export
-- **CSV export** of all training metrics
-- **High-resolution plots** for publication
-- **Detailed logging** with scientific notation formatting
-
-## Key Insights
-
-The unified LDM model allows direct comparison of training methodologies:
-
-### NODE Training (Direct ODE Integration)
-- **Pros**: More mathematically rigorous, potentially higher accuracy
-- **Cons**: Slower training due to ODE solver calls
-- **Use when**: Accuracy is critical, computational time is not a constraint
-- **Config**: Includes ODE solver parameters (`ode_method`, `rtol`, `atol`)
-
-### Weak Form Training  
-- **Pros**: Faster training, good approximation of dynamics
-- **Cons**: Approximate method, may sacrifice some accuracy
-- **Use when**: Fast training is needed, approximate dynamics are acceptable
-- **Config**: Includes weak form parameters (`reconstruction_weight`, `dynamics_weight`)
-
-## Model Architecture
-
-Both approaches use the identical LDM architecture:
-- **Encoder**: Maps (state, control) → latent space
-- **Dynamics**: Learns latent space derivatives  
-- **Decoder**: Maps latent space → state space
-
-The only difference is the training loss function:
-- NODE: Integrates the learned dynamics and compares to ground truth
-- Weak Form: Uses weak form PDE loss without explicit integration
+Training artifacts are written next to this example under the configured model name.

--- a/examples/double_pendulum/double_pendulum_train.py
+++ b/examples/double_pendulum/double_pendulum_train.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 from dymad.models import KBF, LDM
@@ -12,6 +11,7 @@ logging.basicConfig(level=logging.INFO)
 
 B = 128
 N = 501
+DATA_PATH = "./data/dp_data.npz"
 t_grid = np.linspace(0, 5, N)
 
 
@@ -46,21 +46,36 @@ def g(t, x, u):
     return x
 
 
+def describe_model(model):
+    model_spec = getattr(model, "model_spec", None)
+    if model_spec is not None and getattr(model_spec, "name", None):
+        return model_spec.name
+    return getattr(model, "__name__", model.__class__.__name__)
+
+
+def ensure_dataset(path=DATA_PATH):
+    if os.path.exists(path):
+        return
+    logging.info("Generating double pendulum dataset at %s", path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    sampler = TrajectorySampler(f, g, config="double_pendulum_data.yaml")
+    ts, xs, us, ys = sampler.sample(t_grid, batch=B)
+    np.savez_compressed(path, t=ts, x=ys, u=us)
+
+
 ifdat = 0  # Generate data
 ifchk = 0  # Check Data
 iftrn = 1  # Train model
 
 if ifdat:
-    os.makedirs("./data", exist_ok=True)
-    sampler = TrajectorySampler(f, g, config="double_pendulum_data.yaml")
-    ts, xs, us, ys = sampler.sample(t_grid, batch=B)
-    np.savez_compressed("./data/dp_data.npz", t=ts, x=ys, u=us)
+    ensure_dataset()
 
 if ifchk:
     import matplotlib.pyplot as plt
 
     fig, axs = plt.subplots(4, 4, figsize=(20, 20))
-    data = np.load("./data/dp_data.npz")
+    ensure_dataset()
+    data = np.load(DATA_PATH)
     t = data["t"]
     x = data["x"]
 
@@ -77,6 +92,7 @@ if ifchk:
 
 case = 0
 if iftrn:
+    ensure_dataset()
     cases = [
         {"model": LDM, "trainer": NODETrainer, "config": "dp_ldm_node.yaml"},
         {"model": LDM, "trainer": WeakFormTrainer, "config": "dp_ldm_wf.yaml"},
@@ -89,7 +105,10 @@ if iftrn:
     config_path = cases[case]["config"]
     setup_logging(config_path, mode="info", prefix="./logs")
     logging.info(
-        f"Starting Training : {Model.__name__} with {Trainer.__name__} using config {config_path}"
+        "Starting Training : %s with %s using config %s",
+        describe_model(Model),
+        Trainer.__name__,
+        config_path,
     )
     trainer = Trainer(config_path, Model)
     trainer.train()

--- a/examples/double_pendulum/dp_kbf_node.yaml
+++ b/examples/double_pendulum/dp_kbf_node.yaml
@@ -3,6 +3,7 @@ data:
   n_samples: 128
   n_steps: 501
   double_precision: false
+  split_seed: 7
 
 transform_x:
   type: "identity"
@@ -28,18 +29,21 @@ model:
   input_order: "cubic"
   autoencoder_type: "smp"
 
-training:
-  n_epochs: 500
-  save_interval: 10
-  load_checkpoint: false
-  learning_rate: 5e-2
-  decay_rate: 0.999
-  reconstruction_weight: 0.0
-  dynamics_weight: 1.0 
-  sweep_lengths: [50, 100, 150, 200, 250, 300] 
-  sweep_tolerances: [1e-2, 5e-3, 1e-3, 5e-4, 1e-4, 5e-5, 1e-5]  
-  sweep_epoch_step: 100  
-  ode_method: 'dopri5' 
-  ode_args:
-    rtol: 1.e-6  
-    atol: 1.e-8  
+phases:
+  - type: optimizer
+    name: node
+    trainer: NODE
+    n_epochs: 500
+    save_interval: 10
+    load_checkpoint: false
+    learning_rate: 5e-2
+    decay_rate: 0.999
+    reconstruction_weight: 0.0
+    dynamics_weight: 1.0
+    sweep_lengths: [50, 100, 150, 200, 250, 300]
+    sweep_tolerances: [1e-2, 5e-3, 1e-3, 5e-4, 1e-4, 5e-5, 1e-5]
+    sweep_epoch_step: 100
+    ode_method: 'dopri5'
+    ode_args:
+      rtol: 1.e-6
+      atol: 1.e-8

--- a/examples/double_pendulum/dp_kbf_wf.yaml
+++ b/examples/double_pendulum/dp_kbf_wf.yaml
@@ -3,6 +3,7 @@ data:
   n_samples: 128
   n_steps: 501
   double_precision: false
+  split_seed: 7
 
 transform_x:
   type: "identity"
@@ -28,16 +29,19 @@ model:
   input_order: "cubic"
   autoencoder_type: "smp"
 
-training:
-  n_epochs: 500
-  save_interval: 10
-  load_checkpoint: false
-  learning_rate: 1e-2
-  decay_rate: 0.999
-  reconstruction_weight: 1.0
-  dynamics_weight: 1.0
-  weak_form_params:
-    N: 13
-    dN: 2
-    ordpol: 2
-    ordint: 2
+phases:
+  - type: optimizer
+    name: weak_form
+    trainer: Weak
+    n_epochs: 500
+    save_interval: 10
+    load_checkpoint: false
+    learning_rate: 1e-2
+    decay_rate: 0.999
+    reconstruction_weight: 1.0
+    dynamics_weight: 1.0
+    weak_form_params:
+      N: 13
+      dN: 2
+      ordpol: 2
+      ordint: 2

--- a/examples/double_pendulum/dp_ldm_node.yaml
+++ b/examples/double_pendulum/dp_ldm_node.yaml
@@ -3,6 +3,7 @@ data:
   n_samples: 128
   n_steps: 501
   double_precision: false
+  split_seed: 7
 
 transform_x:
   type: "identity"
@@ -26,18 +27,21 @@ model:
   weight_init: "xavier_uniform"
   input_order: "cubic"
 
-training:
-  n_epochs: 3000
-  save_interval: 10
-  load_checkpoint: false
-  learning_rate: 5e-2 
-  decay_rate: 0.999
-  reconstruction_weight: 0.0
-  dynamics_weight: 1.0
-  sweep_lengths: [50, 100, 150, 200, 250, 300]
-  sweep_tolerances: [1e-2, 5e-3, 1e-3, 5e-4, 1e-4, 5e-5, 1e-5]  
-  sweep_epoch_step: 300  
-  ode_method: 'dopri5'  
-  ode_args:
-    rtol: 1.e-6
-    atol: 1.e-8
+phases:
+  - type: optimizer
+    name: node
+    trainer: NODE
+    n_epochs: 3000
+    save_interval: 10
+    load_checkpoint: false
+    learning_rate: 5e-2
+    decay_rate: 0.999
+    reconstruction_weight: 0.0
+    dynamics_weight: 1.0
+    sweep_lengths: [50, 100, 150, 200, 250, 300]
+    sweep_tolerances: [1e-2, 5e-3, 1e-3, 5e-4, 1e-4, 5e-5, 1e-5]
+    sweep_epoch_step: 300
+    ode_method: 'dopri5'
+    ode_args:
+      rtol: 1.e-6
+      atol: 1.e-8

--- a/examples/double_pendulum/dp_ldm_wf.yaml
+++ b/examples/double_pendulum/dp_ldm_wf.yaml
@@ -3,6 +3,7 @@ data:
   n_samples: 128
   n_steps: 501
   double_precision: false
+  split_seed: 7
 
 transform_x:
   type: "identity"
@@ -26,16 +27,19 @@ model:
   weight_init: "xavier_uniform"
   input_order: "cubic"
 
-training:
-  n_epochs: 500
-  save_interval: 10
-  load_checkpoint: false
-  learning_rate: 1e-2
-  decay_rate: 0.999
-  reconstruction_weight: 1.0
-  dynamics_weight: 1.0
-  weak_form_params:
-    N: 13
-    dN: 2
-    ordpol: 2
-    ordint: 2
+phases:
+  - type: optimizer
+    name: weak_form
+    trainer: Weak
+    n_epochs: 500
+    save_interval: 10
+    load_checkpoint: false
+    learning_rate: 1e-2
+    decay_rate: 0.999
+    reconstruction_weight: 1.0
+    dynamics_weight: 1.0
+    weak_form_params:
+      N: 13
+      dN: 2
+      ordpol: 2
+      ordint: 2

--- a/examples/double_pendulum/main.ipynb
+++ b/examples/double_pendulum/main.ipynb
@@ -1,0 +1,250 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Example: Double Pendulum\n",
+        "\n",
+        "This notebook is the supported interactive entrypoint for `examples/double_pendulum`.\n",
+        "It uses the current `phases` config shape and applies a small `config_mod` overlay so the run stays notebook-friendly.\n",
+        "\n",
+        "The `deprecated/` folder is kept only for historical comparison material.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from pathlib import Path\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "import yaml\n",
+        "\n",
+        "from dymad.io import load_model\n",
+        "from dymad.models import KBF\n",
+        "from dymad.training import WeakFormTrainer\n",
+        "from dymad.utils import TrajectorySampler, plot_summary\n",
+        "\n",
+        "SEED = 7\n",
+        "np.random.seed(SEED)\n",
+        "torch.manual_seed(SEED)\n",
+        "\n",
+        "cwd = Path.cwd().resolve()\n",
+        "if (cwd / \"examples\" / \"double_pendulum\").exists():\n",
+        "    EXAMPLE_DIR = cwd / \"examples\" / \"double_pendulum\"\n",
+        "elif cwd.name == \"double_pendulum\":\n",
+        "    EXAMPLE_DIR = cwd\n",
+        "else:\n",
+        "    raise RuntimeError(\"Run this notebook from the repo root or from examples/double_pendulum.\")\n",
+        "\n",
+        "os.chdir(EXAMPLE_DIR)\n",
+        "DATA_DIR = EXAMPLE_DIR / \"data\"\n",
+        "DATA_DIR.mkdir(exist_ok=True)\n",
+        "\n",
+        "print(f\"Working directory: {EXAMPLE_DIR}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Data Generation\n",
+        "\n",
+        "We keep the full double-pendulum dynamics, but use a smaller dataset than the tracked YAML defaults so the notebook can be rerun quickly.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "BATCH = 16\n",
+        "N_STEPS = 151\n",
+        "t_grid = np.linspace(0.0, 5.0, N_STEPS)\n",
+        "DATA_PATH = DATA_DIR / \"dp_demo.npz\"\n",
+        "\n",
+        "\n",
+        "def f(t, x, u):\n",
+        "    dx = np.zeros_like(x)\n",
+        "    m1, m2 = 1.0, 1.0\n",
+        "    l1, l2 = 1.0, 1.0\n",
+        "    g = 9.81\n",
+        "    th1, th2, w1, w2 = x[0], x[1], x[2], x[3]\n",
+        "\n",
+        "    dx[0] = w1\n",
+        "    dx[1] = w2\n",
+        "    dx[2] = (\n",
+        "        -g * (2 * m1 + m2) * np.sin(th1)\n",
+        "        - m2 * g * np.sin(th1 - 2 * th2)\n",
+        "        - 2 * np.sin(th1 - th2) * m2 * (l2 * w2**2 + l1 * w1**2 * np.cos(th1 - th2))\n",
+        "    ) / (l1 * (2 * m1 + m2 - m2 * np.cos(2 * th1 - 2 * th2)))\n",
+        "    dx[3] = (\n",
+        "        2\n",
+        "        * np.sin(th1 - th2)\n",
+        "        * (\n",
+        "            l1 * w1**2 * (m1 + m2)\n",
+        "            + g * (m1 + m2) * np.cos(th1)\n",
+        "            + l2 * w2**2 * m2 * np.cos(th1 - th2)\n",
+        "        )\n",
+        "    ) / (l2 * (2 * m1 + m2 - m2 * np.cos(2 * th1 - 2 * th2)))\n",
+        "    return dx\n",
+        "\n",
+        "\n",
+        "def g(t, x, u):\n",
+        "    return x\n",
+        "\n",
+        "\n",
+        "sampler = TrajectorySampler(f, g, config=\"double_pendulum_data.yaml\", rng=SEED)\n",
+        "ts, xs, us, ys = sampler.sample(t_grid, batch=BATCH, save=str(DATA_PATH))\n",
+        "\n",
+        "print(f\"Saved dataset to {DATA_PATH}\")\n",
+        "print(f\"t shape: {ts.shape}, x shape: {xs.shape}, u shape: {us.shape}, y shape: {ys.shape}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "labels = [\"theta_1\", \"theta_2\", \"omega_1\", \"omega_2\"]\n",
+        "fig, axes = plt.subplots(2, 2, figsize=(10, 6), sharex=True)\n",
+        "for i, ax in enumerate(axes.flat):\n",
+        "    ax.plot(ts[0], ys[0, :, i], color=\"black\", linewidth=1.5)\n",
+        "    ax.set_title(labels[i])\n",
+        "    ax.set_xlabel(\"time\")\n",
+        "    ax.grid(alpha=0.2)\n",
+        "plt.tight_layout()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Current Config Shape\n",
+        "\n",
+        "The tracked example configs use explicit `phases` entries. For the notebook run, we keep the same surface and only override a few values through `config_mod`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "with open(\"dp_kbf_wf.yaml\", encoding=\"utf-8\") as handle:\n",
+        "    base_config = yaml.safe_load(handle)\n",
+        "\n",
+        "base_config[\"phases\"]\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "config_mod = {\n",
+        "    \"data\": {\n",
+        "        \"path\": str(DATA_PATH),\n",
+        "        \"n_samples\": BATCH,\n",
+        "        \"n_steps\": N_STEPS,\n",
+        "        \"split_seed\": SEED,\n",
+        "    },\n",
+        "    \"model\": {\n",
+        "        \"name\": \"dp_kbf_wf_demo\",\n",
+        "        \"hidden_dimension\": 16,\n",
+        "        \"koopman_dimension\": 8,\n",
+        "    },\n",
+        "    \"dataloader\": {\"batch_size\": 16},\n",
+        "    \"phases\": [\n",
+        "        {\n",
+        "            \"type\": \"optimizer\",\n",
+        "            \"name\": \"weak_form\",\n",
+        "            \"trainer\": \"Weak\",\n",
+        "            \"n_epochs\": 5,\n",
+        "            \"save_interval\": 1,\n",
+        "            \"load_checkpoint\": False,\n",
+        "            \"learning_rate\": 1e-2,\n",
+        "            \"decay_rate\": 0.999,\n",
+        "            \"reconstruction_weight\": 1.0,\n",
+        "            \"dynamics_weight\": 1.0,\n",
+        "            \"weak_form_params\": {\n",
+        "                \"N\": 13,\n",
+        "                \"dN\": 2,\n",
+        "                \"ordpol\": 2,\n",
+        "                \"ordint\": 2,\n",
+        "            },\n",
+        "        }\n",
+        "    ],\n",
+        "}\n",
+        "\n",
+        "torch.manual_seed(SEED)\n",
+        "trainer = WeakFormTrainer(\"dp_kbf_wf.yaml\", KBF, config_mod=config_mod)\n",
+        "_ = trainer.train()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "_ = plot_summary([\"dp_kbf_wf_demo\"], labels=[\"KBF / weak form\"], ifclose=False)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Prediction Check\n",
+        "\n",
+        "Load the trained checkpoint and compare it against one fresh trajectory sampled with a different RNG seed.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "eval_sampler = TrajectorySampler(f, g, config=\"double_pendulum_data.yaml\", rng=SEED + 1)\n",
+        "t_eval, x_eval, u_eval, y_eval = eval_sampler.sample(t_grid, batch=1)\n",
+        "\n",
+        "_, predict_fn = load_model(KBF, \"dp_kbf_wf_demo/dp_kbf_wf_demo.pt\")\n",
+        "with torch.no_grad():\n",
+        "    pred = predict_fn(x_eval[0], t_eval[0], u=u_eval[0])\n",
+        "\n",
+        "fig, axes = plt.subplots(2, 2, figsize=(10, 6), sharex=True)\n",
+        "for i, ax in enumerate(axes.flat):\n",
+        "    ax.plot(t_eval[0], x_eval[0, :, i], label=\"truth\", color=\"black\", linewidth=1.5)\n",
+        "    ax.plot(t_eval[0], pred[:, i], \"--\", label=\"prediction\", color=\"#c0392b\", linewidth=1.5)\n",
+        "    ax.set_title(labels[i])\n",
+        "    ax.set_xlabel(\"time\")\n",
+        "    ax.grid(alpha=0.2)\n",
+        "axes[0, 0].legend(loc=\"best\")\n",
+        "plt.tight_layout()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #63

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 4.47s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 91.93s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-63/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 421 passed, 76 deselected, 29 warnings in 88.79s (0:01:28) ==========

stderr:

## Changed files
- examples/double_pendulum/README.md
- examples/double_pendulum/double_pendulum_train.py
- examples/double_pendulum/dp_kbf_node.yaml
- examples/double_pendulum/dp_kbf_wf.yaml
- examples/double_pendulum/dp_ldm_node.yaml
- examples/double_pendulum/dp_ldm_wf.yaml
- examples/double_pendulum/main.ipynb

## Agent notes
See diff for implementation details.
