### PR TITLE
Fix #68: ipynb update 8: refresh simple_pendulum notebooks

### DIFF
--- a/examples/simple_pendulum/part1.ipynb
+++ b/examples/simple_pendulum/part1.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "- Author: Dr. Daning Huang\n",
     "- Date: 11/09/2025\n",
-    "- Updated: 12/08/2025"
+    "- Updated: 05/07/2026"
    ]
   },
   {
@@ -511,14 +511,6 @@
     "    np.array(res), t_data, \"DP\",\n",
     "    labels=['Truth'] + labels, ifclose=False)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d9006b3f-ab69-4f5f-a95c-057f9760a5a1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/simple_pendulum/part1.ipynb
+++ b/examples/simple_pendulum/part1.ipynb
@@ -105,7 +105,7 @@
     "import torch\n",
     "\n",
     "from dymad.io import load_model\n",
-    "from dymad.models import TemplateCorrAlg      # New object\n",
+    "from dymad.models.recipes_corr import TemplateCorrAlg\n",
     "from dymad.training import WeakFormTrainer\n",
     "from dymad.utils import plot_multi_trajs, plot_summary, TrajectorySampler"
    ]
@@ -270,7 +270,7 @@
    "source": [
     "### Creating the model - Pure torch\n",
     "\n",
-    "Unlike other models, such as `KBF` and `LDM`, that can be used out of the box, to define a physics-infused model, we need to start from a `TemplateCorrAlg` class.  This class handles the interface to the other parts of `DyMAD` (training, plotting, etc.) and only needs one user-customized component: `base_dynamics`, which defines $\\hat{f}$ discussed above.\n",
+    "Unlike other models, such as `KBF` and `LDM`, that can be used out of the box, to define a physics-infused model, we need to start from the `TemplateCorrAlg` recipe class in `dymad.models.recipes_corr`.  This class handles the interface to the other parts of `DyMAD` (training, plotting, etc.) and only needs one user-customized component: `base_dynamics`, which defines $\\hat{f}$ discussed above.\n",
     "\n",
     "> The main caveat is that the arguments are multi-dimensional, often in shapes of `[n_batch, n_step, n_dim]`.  Hence to access the desired variable, say $x_2$ in $x$, use indices `x[..., 1]`, where `...` represents all the dimensions except the last one."
    ]
@@ -501,7 +501,10 @@
     "    mdl, MDL, _, _ = cfgs[i]\n",
     "    _, prd_func = load_model(MDL, f'res_{mdl}.pt')\n",
     "    with torch.no_grad():\n",
-    "        pred = prd_func(x_data, t_data, p=p_data)\n",
+    "        pred = np.stack(\n",
+    "            [prd_func(x_data[j], t_data, p=p_data[j]) for j in range(len(x_data))],\n",
+    "            axis=0,\n",
+    "        )\n",
     "    res.append(pred)\n",
     "\n",
     "plot_multi_trajs(\n",

--- a/examples/simple_pendulum/part2.ipynb
+++ b/examples/simple_pendulum/part2.ipynb
@@ -84,7 +84,7 @@
     "import torch\n",
     "\n",
     "from dymad.io import load_model\n",
-    "from dymad.models import TemplateCorrDif\n",
+    "from dymad.models.recipes_corr import TemplateCorrDif\n",
     "from dymad.training import NODETrainer\n",
     "from dymad.utils import plot_multi_trajs, TrajectorySampler"
    ]
@@ -199,7 +199,7 @@
    "id": "4cff5a8c-f129-4d76-978a-b16bd30bf262",
    "metadata": {},
    "source": [
-    "The configurations for model.  Incremental from the previous part are the options `hidden_layers` and `hidden_dimension`, that define the depth and state dimension of the hidden dynamics.  They are both one, to correspond to the assumed linear form.\n",
+    "The configurations for model.  Incremental from the previous part are the options `latent_layers` and `latent_dimension`, which define the depth and state dimension of the learned hidden dynamics.  They are both one here to correspond to the assumed linear form.  The residual-network options from part 1 are still present as well.\n",
     "\n",
     "Since the hidden states would not be known before training, we need to use NODE training here."
    ]
@@ -240,7 +240,7 @@
    "outputs": [],
    "source": [
     "mdl_kl = {\n",
-    "    \"name\" : 'res_model',\n",
+    "    \"name\" : 'dyn_model',\n",
     "    \"encoder_layers\" : 1,\n",
     "    \"decoder_layers\" : 1,\n",
     "    \"residual_layers\" : 1,\n",
@@ -254,13 +254,13 @@
     "    \"gain\" : 0.1,}\n",
     "\n",
     "trn_nd = {\n",
-    "    \"n_epochs\": 400,\n",
+    "    \"n_epochs\": 500,\n",
     "    \"save_interval\": 50,\n",
     "    \"load_checkpoint\": False,\n",
     "    \"learning_rate\": 5e-3,\n",
     "    \"decay_rate\": 0.999,\n",
-    "    \"sweep_lengths\": [5, 10],\n",
-    "    \"sweep_epoch_step\": 200,\n",
+    "    \"sweep_lengths\": [5, 10, 15, 20],\n",
+    "    \"sweep_epoch_step\": 100,\n",
     "    \"ode_method\": \"dopri5\",\n",
     "    \"ode_args\": {\n",
     "        \"rtol\": 1.e-7,\n",
@@ -276,7 +276,7 @@
    "source": [
     "### Creating the model\n",
     "\n",
-    "Similar to the algebraic correction, here we use a `TemplateCorrDif` class to account for hidden dynamics.  Only the physics-based component needs to be defined, and the class handles the rest.\n",
+    "Similar to the algebraic correction, here we use the `TemplateCorrDif` recipe class from `dymad.models.recipes_corr` to account for hidden dynamics.  Only the physics-based component needs to be defined, and the class handles the rest.\n",
     "\n",
     "But here we do customize the autoencoder too, to avoid additional need for state estimation.  The encoder needs to estimate $\\beta$ from $(x,u)$ (or their history) at the initial condition, and here we just set $\\beta=0$ to match the setup in data generation.  The decoder needs to extract the observed states from $z$, which are just the first two elements.\n",
     "\n",
@@ -313,7 +313,7 @@
    "id": "c1daf4f3-d952-4023-a22b-1b57e322486b",
    "metadata": {},
    "source": [
-    "The JAX version will be the same, and not repeated here.  See the counterpart of this example under `dymad/scripts/pirom_dyn` for more details."
+    "The JAX version will be the same, and not repeated here.  See the counterpart of this example under `scripts/pirom_dyn` for more details."
    ]
   },
   {
@@ -424,7 +424,10 @@
     "\n",
     "_, prd_func = load_model(MDL, f'dyn_{mdl}.pt')\n",
     "with torch.no_grad():\n",
-    "    pred = prd_func(x_data, t_data, u=u_data, p=p_data)\n",
+    "    pred = np.stack(\n",
+    "        [prd_func(x_data[j], t_data, u=u_data[j], p=p_data[j]) for j in range(len(x_data))],\n",
+    "        axis=0,\n",
+    "    )\n",
     "\n",
     "plot_multi_trajs(\n",
     "    np.array([x_data, pred]), t_data, \"DP\", us=u_data,\n",

--- a/examples/simple_pendulum/part2.ipynb
+++ b/examples/simple_pendulum/part2.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "- Author: Dr. Daning Huang\n",
     "- Date: 11/09/2025\n",
-    "- Updated: 12/08/2025"
+    "- Updated: 05/07/2026"
    ]
   },
   {


### PR DESCRIPTION
Closes #68

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 4.99s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 92.85s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-68/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 421 passed, 76 deselected, 29 warnings in 89.10s (0:01:29) ==========

stderr:

## Changed files
- examples/simple_pendulum/part1.ipynb
- examples/simple_pendulum/part2.ipynb

## Agent notes
See diff for implementation details.
