### PR TITLE
Fix #78: Simplify `visualize_model` output to focus on model architecture

### DIFF
--- a/src/dymad/io/checkpoint.py
+++ b/src/dymad/io/checkpoint.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from os import PathLike
@@ -698,6 +699,80 @@ def _prepare_visualize_model_input(
     return prepared
 
 
+_VISUAL_GRAPH_NODE_RE = re.compile(r"^\s*(\d+)\s+\[")
+_VISUAL_GRAPH_EDGE_RE = re.compile(r"^\s*(\d+)\s*->\s*(\d+)\b")
+
+
+def _visual_graph_node_id(statement: str) -> int | None:
+    match = _VISUAL_GRAPH_NODE_RE.match(statement)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _visual_graph_edge_node_ids(statement: str) -> tuple[int, int] | None:
+    match = _VISUAL_GRAPH_EDGE_RE.match(statement)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _output_path_visual_node_ids(model_graph: Any) -> set[int]:
+    reverse_edges: dict[str, set[str]] = {}
+    node_names: dict[str, str] = {}
+    for tail, head in model_graph.edge_list:
+        tail_id = str(tail.node_id)
+        head_id = str(head.node_id)
+        node_names[tail_id] = str(tail.name)
+        node_names[head_id] = str(head.name)
+        reverse_edges.setdefault(head_id, set()).add(tail_id)
+
+    id_dict = cast(dict[str, int], model_graph.id_dict)
+    output_node_ids = [
+        node_id
+        for node_id, name in node_names.items()
+        if name == "output-tensor" and node_id in id_dict
+    ]
+    if not output_node_ids:
+        return set(id_dict.values())
+
+    keep_node_ids: set[str] = set()
+    pending = list(output_node_ids)
+    while pending:
+        node_id = pending.pop()
+        if node_id in keep_node_ids:
+            continue
+        keep_node_ids.add(node_id)
+        pending.extend(reverse_edges.get(node_id, ()))
+
+    return {id_dict[node_id] for node_id in keep_node_ids if node_id in id_dict}
+
+
+def _prune_visual_graph_to_output_paths(model_graph: Any) -> None:
+    keep_ids = _output_path_visual_node_ids(model_graph)
+    if not keep_ids:
+        return
+
+    pruned_body = []
+    for statement in model_graph.visual_graph.body:
+        node_id = _visual_graph_node_id(statement)
+        if node_id is not None:
+            if node_id in keep_ids:
+                pruned_body.append(statement)
+            continue
+
+        edge_ids = _visual_graph_edge_node_ids(statement)
+        if edge_ids is not None:
+            if edge_ids[0] in keep_ids and edge_ids[1] in keep_ids:
+                pruned_body.append(statement)
+            continue
+
+        pruned_body.append(statement)
+
+    model_graph.visual_graph.body = pruned_body
+    model_graph.resize_graph()
+
+
 def visualize_model(
     mdl_class=None,
     checkpoint_path=None,
@@ -707,6 +782,7 @@ def visualize_model(
     depth=1,
     device="cpu",
     ifsave=False,
+    show_all_paths=False,
 ):
     try:
         from torchview import draw_graph
@@ -749,6 +825,8 @@ def visualize_model(
     input_data = _prepare_visualize_model_input(input_data)
 
     model_graph = draw_graph(model, input_data=input_data, depth=depth, device=device)
+    if not show_all_paths:
+        _prune_visual_graph_to_output_paths(model_graph)
 
     if ifsave:
         if checkpoint_path is None:

--- a/src/dymad/io/checkpoint.py
+++ b/src/dymad/io/checkpoint.py
@@ -624,26 +624,76 @@ def load_model(
 def _prepare_visualize_model_input(
     input_data: dict[str, Any],
 ) -> dict:
+    # torchview renders the concrete input tensors alongside the module graph.
+    # Collapse checkpoint prediction payloads to one representative sample/step so
+    # the visualization emphasizes model structure instead of batch, horizon, and
+    # padded graph-topology details.
+    def _take_first_batch_item(payload: Any) -> Any:
+        if isinstance(payload, torch.Tensor) and payload.ndim >= 2:
+            return payload[0]
+        return payload
+
+    def _take_first_value(payload: Any) -> Any:
+        if isinstance(payload, torch.Tensor) and payload.ndim >= 1:
+            return payload[0]
+        return payload
+
+    def _take_first_step(payload: Any) -> Any:
+        if isinstance(payload, torch.Tensor) and payload.ndim >= 2:
+            return payload[0]
+        return payload
+
+    def _coarsen_graph_payload(payload: Any, *, squeeze_vector: bool = False) -> Any:
+        if payload is None:
+            return None
+        if isinstance(payload, torch.Tensor) and getattr(payload, "is_nested", False):
+            values = payload.unbind()
+            return _coarsen_graph_payload(
+                values[0] if values else None, squeeze_vector=squeeze_vector
+            )
+        if isinstance(payload, tuple):
+            if (
+                len(payload) == 2
+                and all(isinstance(item, torch.Tensor) for item in payload)
+                and cast(torch.Tensor, payload[1]).ndim == 1
+            ):
+                values = cast(torch.Tensor, payload[0])
+                offsets = cast(torch.Tensor, payload[1])
+                if offsets.numel() >= 2:
+                    return _coarsen_graph_payload(
+                        values[offsets[0] : offsets[1]],
+                        squeeze_vector=squeeze_vector,
+                    )
+            if not payload:
+                return payload
+            return _coarsen_graph_payload(payload[0], squeeze_vector=squeeze_vector)
+        if isinstance(payload, list):
+            if not payload:
+                return payload
+            return _coarsen_graph_payload(payload[0], squeeze_vector=squeeze_vector)
+        if isinstance(payload, torch.Tensor):
+            if payload.ndim >= 4:
+                return _coarsen_graph_payload(payload[0, 0], squeeze_vector=squeeze_vector)
+            if payload.ndim == 3:
+                return _coarsen_graph_payload(payload[0], squeeze_vector=squeeze_vector)
+            if squeeze_vector and payload.ndim == 2:
+                if payload.shape[-1] == 1:
+                    return payload.squeeze(-1)
+                return payload[0]
+        return payload
+
     prepared = dict(input_data)
-
-    t = prepared.get("t")
-    if isinstance(t, torch.Tensor):
-        if t.ndim >= 2:
-            prepared["t"] = t[:, :1]
-        elif t.ndim == 1 and t.numel() > 1:
-            prepared["t"] = t[:1]
-
-    u = prepared.get("u")
-    if isinstance(u, torch.Tensor):
-        if u.ndim >= 3:
-            prepared["u"] = u[:, :1, ...]
-        elif u.ndim == 2 and u.shape[0] > 1:
-            prepared["u"] = u[:1, ...]
+    x_payload = prepared.get("x")
+    prepared["x"] = _take_first_batch_item(x_payload)
+    # A 1D `p` is the shared-parameter-vector form across regular and graph
+    # prediction helpers, even when its length happens to match the source batch.
+    # Only trim an explicit batch axis from higher-rank param payloads.
+    prepared["p"] = _take_first_batch_item(prepared.get("p"))
+    prepared["t"] = _take_first_value(_take_first_batch_item(prepared.get("t")))
+    prepared["u"] = _take_first_step(_take_first_batch_item(prepared.get("u")))
 
     for key in ("ei", "ew", "ea"):
-        payload = prepared.get(key)
-        if isinstance(payload, torch.Tensor) and getattr(payload, "is_nested", False):
-            prepared[key] = [item for item in payload.unbind()]
+        prepared[key] = _coarsen_graph_payload(prepared.get(key), squeeze_vector=(key == "ew"))
 
     return prepared
 

--- a/tests/test_contract_visualize_model_input.py
+++ b/tests/test_contract_visualize_model_input.py
@@ -3,14 +3,17 @@ import torch
 from dymad.io.checkpoint import _prepare_visualize_model_input
 
 
-def test_prepare_visualize_model_input_normalizes_graph_prediction_payload():
+def test_prepare_visualize_model_input_reduces_batched_prediction_payload():
     input_data = {
-        "t": torch.arange(5, dtype=torch.float32).reshape(1, 5),
-        "x": torch.tensor([1.0, 2.0, 3.0, 4.0]),
-        "u": torch.arange(15, dtype=torch.float32).reshape(1, 5, 3),
-        "p": None,
+        "t": torch.arange(10, dtype=torch.float32).reshape(2, 5),
+        "x": torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        "u": torch.arange(30, dtype=torch.float32).reshape(2, 5, 3),
+        "p": torch.arange(4, dtype=torch.float32).reshape(2, 2),
         "ei": torch.tensor(
-            [[[0, 1], [1, 0], [1, 2], [2, 1]]],
+            [
+                [[0, 1], [1, 0], [1, 2], [2, 1]],
+                [[0, 2], [2, 0], [2, 1], [1, 2]],
+            ],
             dtype=torch.long,
         ),
         "ew": None,
@@ -19,6 +22,113 @@ def test_prepare_visualize_model_input_normalizes_graph_prediction_payload():
 
     prepared = _prepare_visualize_model_input(input_data)
 
-    assert torch.equal(prepared["t"], torch.tensor([[0.0]]))
-    assert torch.equal(prepared["u"], torch.tensor([[[0.0, 1.0, 2.0]]]))
-    assert torch.equal(prepared["ei"], input_data["ei"])
+    assert torch.equal(prepared["t"], torch.tensor(0.0))
+    assert torch.equal(prepared["x"], torch.tensor([0.0, 1.0, 2.0, 3.0]))
+    assert torch.equal(prepared["u"], torch.tensor([0.0, 1.0, 2.0]))
+    assert torch.equal(prepared["p"], torch.tensor([0.0, 1.0]))
+    assert torch.equal(
+        prepared["ei"],
+        torch.tensor([[0, 1], [1, 0], [1, 2], [2, 1]], dtype=torch.long),
+    )
+
+
+def test_prepare_visualize_model_input_coarsens_graph_runtime_payload():
+    input_data = {
+        "t": torch.arange(6, dtype=torch.float32).reshape(1, 6),
+        "x": torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+        "u": torch.arange(12, dtype=torch.float32).reshape(1, 2, 6),
+        "p": None,
+        "ei": torch.tensor(
+            [
+                [
+                    [[0, 1], [1, 0], [1, 2], [2, 1]],
+                    [[0, 1], [1, 0], [1, 2], [2, 1]],
+                ]
+            ],
+            dtype=torch.long,
+        ),
+        "ew": torch.tensor([[[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]]),
+        "ea": torch.arange(16, dtype=torch.float32).reshape(1, 2, 4, 2),
+    }
+
+    prepared = _prepare_visualize_model_input(input_data)
+
+    assert torch.equal(
+        prepared["ei"],
+        torch.tensor([[0, 1], [1, 0], [1, 2], [2, 1]], dtype=torch.long),
+    )
+    assert torch.equal(prepared["ew"], torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    assert torch.equal(
+        prepared["ea"],
+        torch.tensor(
+            [
+                [0.0, 1.0],
+                [2.0, 3.0],
+                [4.0, 5.0],
+                [6.0, 7.0],
+            ]
+        ),
+    )
+
+
+def test_prepare_visualize_model_input_preserves_single_feature_edge_attr_shape():
+    input_data = {
+        "t": torch.arange(6, dtype=torch.float32).reshape(1, 6),
+        "x": torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+        "u": torch.arange(12, dtype=torch.float32).reshape(1, 2, 6),
+        "p": None,
+        "ei": torch.tensor(
+            [
+                [
+                    [[0, 1], [1, 0], [1, 2], [2, 1]],
+                    [[0, 1], [1, 0], [1, 2], [2, 1]],
+                ]
+            ],
+            dtype=torch.long,
+        ),
+        "ew": torch.tensor([[[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]]),
+        "ea": torch.arange(8, dtype=torch.float32).reshape(1, 2, 4, 1),
+    }
+
+    prepared = _prepare_visualize_model_input(input_data)
+
+    assert torch.equal(prepared["ew"], torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    assert torch.equal(
+        prepared["ea"],
+        torch.tensor([[0.0], [1.0], [2.0], [3.0]]),
+    )
+    assert prepared["ea"].shape == (4, 1)
+
+
+def test_prepare_visualize_model_input_reduces_explicit_param_batches():
+    input_data = {
+        "t": torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        "x": torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        "u": None,
+        "p": torch.tensor([[5.0], [6.0]]),
+        "ei": None,
+        "ew": None,
+        "ea": None,
+    }
+
+    prepared = _prepare_visualize_model_input(input_data)
+
+    assert torch.equal(prepared["x"], torch.tensor([0.0, 1.0, 2.0, 3.0]))
+    assert torch.equal(prepared["p"], torch.tensor([5.0]))
+
+
+def test_prepare_visualize_model_input_preserves_shared_param_vectors():
+    input_data = {
+        "t": torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        "x": torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        "u": None,
+        "p": torch.tensor([5.0, 6.0]),
+        "ei": None,
+        "ew": None,
+        "ea": None,
+    }
+
+    prepared = _prepare_visualize_model_input(input_data)
+
+    assert torch.equal(prepared["x"], torch.tensor([0.0, 1.0, 2.0, 3.0]))
+    assert torch.equal(prepared["p"], torch.tensor([5.0, 6.0]))

--- a/tests/test_contract_visualize_model_input.py
+++ b/tests/test_contract_visualize_model_input.py
@@ -1,6 +1,112 @@
+import sys
+from types import ModuleType
+
 import torch
 
-from dymad.io.checkpoint import _prepare_visualize_model_input
+import dymad.io.checkpoint as checkpoint_module
+from dymad.io.checkpoint import (
+    _prepare_visualize_model_input,
+    _prune_visual_graph_to_output_paths,
+    visualize_model,
+)
+
+
+class _FakeVisualGraph:
+    def __init__(self) -> None:
+        self.body = [
+            "\t0 [label=<input-tensor> fillcolor=lightyellow]\n",
+            "\t1 [label=<input-tensor> fillcolor=lightyellow]\n",
+            "\t2 [label=<Sub> fillcolor=darkseagreen1]\n",
+            "\t3 [label=<output-tensor> fillcolor=lightyellow]\n",
+            "\t4 [label=<Other> fillcolor=darkseagreen1]\n",
+            "\t0 -> 2\n",
+            "\t1 -> 4\n",
+            "\t2 -> 3\n",
+        ]
+
+
+class _FakeNode:
+    def __init__(self, node_id: str, name: str) -> None:
+        self.node_id = node_id
+        self.name = name
+
+
+class _FakeModelGraph:
+    def __init__(self) -> None:
+        input_a = _FakeNode("input_a", "input-tensor")
+        input_b = _FakeNode("input_b", "input-tensor")
+        output_subgraph = _FakeNode("output_subgraph", "Sub")
+        output = _FakeNode("output", "output-tensor")
+        unused_subgraph = _FakeNode("unused_subgraph", "Other")
+        self.edge_list = [
+            (input_a, output_subgraph),
+            (input_b, unused_subgraph),
+            (output_subgraph, output),
+        ]
+        self.id_dict = {
+            "input_a": 0,
+            "input_b": 1,
+            "output_subgraph": 2,
+            "output": 3,
+            "unused_subgraph": 4,
+        }
+        self.visual_graph = _FakeVisualGraph()
+        self.resize_called = False
+
+    def resize_graph(self) -> None:
+        self.resize_called = True
+
+
+def test_prune_visual_graph_to_output_paths_drops_non_output_branches():
+    graph = _FakeModelGraph()
+
+    _prune_visual_graph_to_output_paths(graph)
+
+    graph_source = "".join(graph.visual_graph.body)
+    assert "Other" not in graph_source
+    assert "\t1 [" not in graph_source
+    assert "1 -> 4" not in graph_source
+    assert "Sub" in graph_source
+    assert "output-tensor" in graph_source
+    assert "0 -> 2" in graph_source
+    assert "2 -> 3" in graph_source
+    assert graph.resize_called is True
+
+
+def test_visualize_model_skips_output_path_pruning_when_show_all_paths(monkeypatch):
+    graph = _FakeModelGraph()
+    calls = {"prune": 0}
+
+    def fake_draw_graph(*args, **kwargs):
+        return graph
+
+    def fake_prune(model_graph):
+        calls["prune"] += 1
+        _prune_visual_graph_to_output_paths(model_graph)
+
+    fake_torchview = ModuleType("torchview")
+    fake_torchview.draw_graph = fake_draw_graph  # type: ignore[attr-defined]
+    monkeypatch.setattr(checkpoint_module, "_prune_visual_graph_to_output_paths", fake_prune)
+    monkeypatch.setitem(sys.modules, "torchview", fake_torchview)
+
+    visual_graph = visualize_model(
+        model=object(),
+        prd_func=lambda *args, **kwargs: {
+            "t": torch.tensor([0.0]),
+            "x": torch.tensor([[1.0]]),
+            "u": None,
+            "p": None,
+            "ei": None,
+            "ew": None,
+            "ea": None,
+        },
+        ref_data={},
+        show_all_paths=True,
+    )
+
+    assert visual_graph is graph.visual_graph
+    assert calls["prune"] == 0
+    assert "Other" in "".join(graph.visual_graph.body)
 
 
 def test_prepare_visualize_model_input_reduces_batched_prediction_payload():


### PR DESCRIPTION
Closes #78

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 4.57s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 93.49s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-78/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 426 passed, 76 deselected, 29 warnings in 89.71s (0:01:29) ==========

stderr:

## Changed files
- src/dymad/io/checkpoint.py
- tests/test_contract_visualize_model_input.py

## Agent notes
See diff for implementation details.
