### PR TITLE
Fix #81: DT weak form

### DIFF
--- a/src/dymad/agent/registry/training_schema.py
+++ b/src/dymad/agent/registry/training_schema.py
@@ -86,8 +86,10 @@ TRANSLATION_GUIDANCE: tuple[str, ...] = (
     "Use overrides.cv.selection to control model choice policy (goal and tie_breakers).",
     "Supported optimizer trainer names are Linear, OneStep, Weak, and NODE.",
     "Prefer minimal legacy optimizer entries such as {'trainer': 'Linear'} or "
-    "{'trainer': 'Weak'} unless the user asks for explicit phase-level hyperparameters; "
-    "matching trainer defaults from the selected profile are preserved unless overridden.",
+    "{'trainer': 'Weak'} unless the user asks for explicit phase-level hyperparameters. "
+    "Weak automatically uses continuous-time weak derivative matching for continuous models "
+    "and projected one-step residual matching for discrete models; matching trainer defaults "
+    "from the selected profile are preserved unless overridden.",
     "Add phase names only when they improve readability or reflect user-provided "
     "labels such as initialization or refinement.",
 )
@@ -97,6 +99,8 @@ CONSTRAINT_NOTES: tuple[str, ...] = (
     "When the user requests identity encoder/decoder behavior without naming the "
     "latent dimension, inspect the dataset and set the latent dimension to the "
     "dataset state dimension.",
+    "For discrete-time models, Weak uses a projected one-step residual objective in latent "
+    "space; it is not a discrete integration-by-parts formulation.",
 )
 
 

--- a/src/dymad/numerics/__init__.py
+++ b/src/dymad/numerics/__init__.py
@@ -27,7 +27,7 @@ from dymad.numerics.manifold import (
 )
 from dymad.numerics.spectrum import generate_coef, rational_kernel
 from dymad.numerics.time_int import fe_step, rk4_step
-from dymad.numerics.weak import generate_weak_weights
+from dymad.numerics.weak import generate_discrete_weak_weights, generate_weak_weights
 
 __all__ = [
     "central_diff",
@@ -41,6 +41,7 @@ __all__ = [
     "disc2cont",
     "denoise",
     "denoising_metrics",
+    "generate_discrete_weak_weights",
     "DM",
     "DMF",
     "eig_low_rank",

--- a/src/dymad/numerics/weak.py
+++ b/src/dymad/numerics/weak.py
@@ -170,3 +170,37 @@ def generate_weak_weights(
     D = P0 * w0 * w  # shape: (poly_order, N)
 
     return C, D
+
+
+def generate_discrete_weak_weights(
+    dt: float,
+    n_integration_points: int,
+    poly_order: int = 4,
+    int_rule_order: int = 4,
+    normalization: str = "l2",
+) -> np.ndarray:
+    """Generate discrete-time weak projection weights.
+
+    This reuses the non-derivative weak weights as the residual projection bank.
+    Rows can optionally be normalized with an L2 or L1 norm.
+    """
+    _, D = generate_weak_weights(
+        dt=dt,
+        n_integration_points=n_integration_points,
+        poly_order=poly_order,
+        int_rule_order=int_rule_order,
+    )
+    if normalization == "none":
+        return D
+    if normalization == "l2":
+        norms = np.linalg.norm(D, ord=2, axis=1, keepdims=True)
+    elif normalization == "l1":
+        norms = np.linalg.norm(D, ord=1, axis=1, keepdims=True)
+    else:
+        raise ValueError(
+            "Invalid discrete weak weight normalization "
+            f"'{normalization}'. Expected one of 'l2', 'l1', or 'none'."
+        )
+    if np.any(norms == 0.0):
+        raise ValueError("Discrete weak weights contain a zero-norm projection row.")
+    return D / norms

--- a/src/dymad/training/phases.py
+++ b/src/dymad/training/phases.py
@@ -16,7 +16,12 @@ from torch.utils.data import DataLoader
 from dymad.core import GraphSeries, GraphTrainerBatch, RegularSeries, RegularTrainerBatch
 from dymad.core.transform_builder import build_transform_module
 from dymad.losses import LOSS_MAP
-from dymad.numerics import denoise, denoising_metrics, generate_weak_weights
+from dymad.numerics import (
+    denoise,
+    denoising_metrics,
+    generate_discrete_weak_weights,
+    generate_weak_weights,
+)
 from dymad.training.batch_adapter import RuntimeBatch, TrainerBatch, batch_to_runtime
 from dymad.training.execution_services import ExecutionServices
 from dymad.training.ls_update import LSUpdater, _comp_linear_eval_ct, _comp_linear_eval_dt
@@ -1262,6 +1267,33 @@ class NodeOptimizerPhase(BaseOptimizerPhase):
 
 
 class WeakFormOptimizerPhase(BaseOptimizerPhase):
+    def __init__(
+        self,
+        *,
+        spec: PhaseSpec,
+        config: dict[str, Any],
+        model_class: type,
+        dtype: torch.dtype,
+        execution_services: ExecutionServices,
+    ):
+        super().__init__(
+            spec=spec,
+            config=config,
+            model_class=model_class,
+            dtype=dtype,
+            execution_services=execution_services,
+        )
+        self._validate_discrete_weight_normalization()
+
+    def _validate_discrete_weight_normalization(self) -> None:
+        params = cast(OptimizerPhaseSpec, self.spec).config.get("weak_form_params", {})
+        normalization = params.get("discrete_weight_normalization", "l2")
+        if normalization not in {"l2", "l1", "none"}:
+            raise PhaseSpecValidationError(
+                "Weak phase weak_form_params.discrete_weight_normalization must be one of "
+                "'l2', 'l1', or 'none'."
+            )
+
     def _customize_optimizer_artifact(
         self,
         optimizer_state: OptimizerStateArtifact,
@@ -1272,14 +1304,34 @@ class WeakFormOptimizerPhase(BaseOptimizerPhase):
         params = self.spec.config["weak_form_params"]
         dtype = next(model.parameters()).dtype
         train_md = _require_metadata(phase_context.train_md)
-        C, D = generate_weak_weights(
-            dt=train_md["dt_and_n_steps"][0][0],
-            n_integration_points=params["N"],
-            poly_order=params["ordpol"],
-            int_rule_order=params["ordint"],
-        )
-        optimizer_state._weak_C = torch.tensor(C.T, dtype=dtype, device=self.device)
-        optimizer_state._weak_D = torch.tensor(D.T, dtype=dtype, device=self.device)
+        dt = float(train_md["dt_and_n_steps"][0][0])
+        if getattr(model, "CONT", True):
+            C, D = generate_weak_weights(
+                dt=dt,
+                n_integration_points=params["N"],
+                poly_order=params["ordpol"],
+                int_rule_order=params["ordint"],
+            )
+            optimizer_state._weak_C = torch.tensor(C.T, dtype=dtype, device=self.device)
+            optimizer_state._weak_D = torch.tensor(D.T, dtype=dtype, device=self.device)
+        else:
+            n_steps = [int(item[1]) for item in train_md["dt_and_n_steps"]]
+            required_steps = int(params["N"]) + 1
+            if n_steps and min(n_steps) < required_steps:
+                raise PhaseSpecValidationError(
+                    "Discrete Weak phase requires at least "
+                    f"{required_steps} time samples when weak_form_params.N={params['N']} "
+                    "residual weights are requested."
+                )
+            W = generate_discrete_weak_weights(
+                dt=dt,
+                n_integration_points=params["N"],
+                poly_order=params["ordpol"],
+                int_rule_order=params["ordint"],
+                normalization=params.get("discrete_weight_normalization", "l2"),
+            )
+            optimizer_state._weak_C = None
+            optimizer_state._weak_D = torch.tensor(W.T, dtype=dtype, device=self.device)
         optimizer_state._weak_N = params["N"]
         optimizer_state._weak_dN = params["dN"]
 
@@ -1303,12 +1355,36 @@ class WeakFormOptimizerPhase(BaseOptimizerPhase):
         runtime_batch = batch_any.to(self.device)
         runtime = cast(Any, batch_to_runtime(runtime_batch))
         latent = cast(Any, model).encoder(runtime)
-        latent_dot = cast(Any, model).dynamics(latent, runtime)
         x_hat = cast(Any, model).decoder(latent, runtime)
-        z_windows = latent.unfold(1, optimizer_state._weak_N, optimizer_state._weak_dN)
-        z_dot_windows = latent_dot.unfold(1, optimizer_state._weak_N, optimizer_state._weak_dN)
-        true_weak = z_windows @ optimizer_state._weak_C
-        pred_weak = z_dot_windows @ optimizer_state._weak_D
+        weak_n = optimizer_state._weak_N
+        weak_dn = optimizer_state._weak_dN
+        weak_d = optimizer_state._weak_D
+        if weak_n is None or weak_dn is None or weak_d is None:
+            raise ValueError("Weak-form weights are not initialized.")
+
+        if getattr(model, "CONT", True):
+            weak_c = optimizer_state._weak_C
+            if weak_c is None:
+                raise ValueError("Continuous weak-form weights are not initialized.")
+            latent_dot = cast(Any, model).dynamics(latent, runtime)
+            z_windows = latent.unfold(1, weak_n, weak_dn)
+            z_dot_windows = latent_dot.unfold(1, weak_n, weak_dn)
+            true_weak = z_windows @ weak_c
+            pred_weak = z_dot_windows @ weak_d
+        else:
+            if latent.size(1) < weak_n + 1:
+                raise PhaseSpecValidationError(
+                    "Discrete Weak phase requires at least "
+                    f"{weak_n + 1} time samples when weak_form_params.N={weak_n} "
+                    "residual weights are requested."
+                )
+            latent_next = cast(Any, model).dynamics(latent, runtime)[:, :-1, :]
+            target_latent = latent[:, 1:, :].detach()
+            pred_windows = latent_next.unfold(1, weak_n, weak_dn)
+            true_windows = target_latent.unfold(1, weak_n, weak_dn)
+            pred_weak = pred_windows @ weak_d
+            true_weak = true_windows @ weak_d
+
         losses = [optimizer_state.criteria[0](pred_weak, true_weak)]
         losses.extend(
             self._additional_criteria_evaluation(

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -180,8 +180,10 @@ def test_describe_training_capability_exposes_phase_schema_and_override_contract
         "Use overrides.cv.selection to control model choice policy (goal and tie_breakers).",
         "Supported optimizer trainer names are Linear, OneStep, Weak, and NODE.",
         "Prefer minimal legacy optimizer entries such as {'trainer': 'Linear'} or "
-        "{'trainer': 'Weak'} unless the user asks for explicit phase-level hyperparameters; "
-        "matching trainer defaults from the selected profile are preserved unless overridden.",
+        "{'trainer': 'Weak'} unless the user asks for explicit phase-level hyperparameters. "
+        "Weak automatically uses continuous-time weak derivative matching for continuous "
+        "models and projected one-step residual matching for discrete models; matching "
+        "trainer defaults from the selected profile are preserved unless overridden.",
         "Add phase names only when they improve readability or reflect user-provided "
         "labels such as initialization or refinement.",
     )
@@ -191,6 +193,8 @@ def test_describe_training_capability_exposes_phase_schema_and_override_contract
         "When the user requests identity encoder/decoder behavior without naming the "
         "latent dimension, inspect the dataset and set the latent dimension to the "
         "dataset state dimension.",
+        "For discrete-time models, Weak uses a projected one-step residual objective in "
+        "latent space; it is not a discrete integration-by-parts formulation.",
     )
     assert "export_summary" in detail.auto_appended_phases
     assert detail.examples[0].name == "linear_then_node_from_plain_english"

--- a/tests/test_assert_weak.py
+++ b/tests/test_assert_weak.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from dymad.numerics.weak import generate_weak_weights
+from dymad.numerics.weak import generate_discrete_weak_weights, generate_weak_weights
 
 ref = [
     ([1.1692428919931415], [1.1656849312730149]),
@@ -28,3 +28,17 @@ def test_weak_form():
 
         assert np.allclose(C.dot(y), ref[_o - 1][0]), f"Weak weights failed for order {_o}: C*y"
         assert np.allclose(D.dot(dy), ref[_o - 1][1]), f"Weak weights failed for order {_o}: D*dy"
+
+
+def test_discrete_weak_weights_have_expected_shape_and_l2_row_norms():
+    W = generate_discrete_weak_weights(0.1, 7, poly_order=3, int_rule_order=2)
+
+    assert W.shape == (3, 7)
+    assert np.allclose(np.linalg.norm(W, axis=1), np.ones(3))
+
+
+def test_discrete_weak_weights_none_matches_raw_non_derivative_weights():
+    _, D = generate_weak_weights(0.1, 7, 3, 2)
+    W = generate_discrete_weak_weights(0.1, 7, poly_order=3, int_rule_order=2, normalization="none")
+
+    assert np.allclose(W, D)

--- a/tests/test_contract_training_phase_runtime.py
+++ b/tests/test_contract_training_phase_runtime.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 import pytest
@@ -8,7 +9,7 @@ from scipy.signal import savgol_filter
 
 import dymad.training.phases as phases_module
 from dymad.core import GraphSeries, RegularSeries, RegularTrainerBatch
-from dymad.numerics import denoise
+from dymad.numerics import denoise, generate_discrete_weak_weights
 from dymad.training import driver
 from dymad.training.execution_services import ExecutionServices
 from dymad.training.helper import (
@@ -1394,6 +1395,277 @@ def test_one_step_optimizer_phase_detaches_first_order_continuous_targets_for_tr
     assert targets.requires_grad is False
     assert actual_grad is not None
     assert actual_grad.item() == pytest.approx(expected_grad.item())
+
+
+def test_weak_form_optimizer_phase_uses_discrete_projected_residuals():
+    class _DiscreteWeakModel(torch.nn.Module):
+        CONT = False
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(2.0))
+
+        def encoder(self, runtime):
+            return runtime.x
+
+        def dynamics(self, z, runtime):
+            return self.weight * z
+
+        def decoder(self, z, runtime):
+            return z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(
+            name="weak",
+            trainer="Weak",
+            config={"weak_form_params": {"N": 3, "dN": 1, "ordpol": 1, "ordint": 1}},
+        ),
+        config=config,
+        model_class=_DiscreteWeakModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _DiscreteWeakModel()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[torch.nn.MSELoss(), torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+    )
+    phase._customize_optimizer_artifact(
+        optimizer_state,
+        model,
+        PhaseContext(train_md={"dt_and_n_steps": [(1.0, 4)]}),
+        logging.getLogger("test.weak.discrete"),
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0, 3.0]),
+        state=torch.tensor([[1.0], [2.0], [4.0], [8.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    losses = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})
+
+    assert losses[0].item() == pytest.approx(0.0)
+
+
+def test_weak_form_optimizer_phase_matches_expected_discrete_projected_loss():
+    class _DiscreteWeakModel(torch.nn.Module):
+        CONT = False
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+        def encoder(self, runtime):
+            return runtime.x
+
+        def dynamics(self, z, runtime):
+            return self.weight * z
+
+        def decoder(self, z, runtime):
+            return z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(
+            name="weak",
+            trainer="Weak",
+            config={"weak_form_params": {"N": 3, "dN": 1, "ordpol": 1, "ordint": 1}},
+        ),
+        config=config,
+        model_class=_DiscreteWeakModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _DiscreteWeakModel()
+    criterion = torch.nn.MSELoss()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[criterion, torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+    )
+    phase._customize_optimizer_artifact(
+        optimizer_state,
+        model,
+        PhaseContext(train_md={"dt_and_n_steps": [(1.0, 4)]}),
+        logging.getLogger("test.weak.discrete"),
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0, 3.0]),
+        state=torch.tensor([[1.0], [2.0], [4.0], [8.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    loss = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})[0]
+    weights = torch.tensor(
+        generate_discrete_weak_weights(1.0, 3, poly_order=1, int_rule_order=1),
+        dtype=torch.float32,
+    )
+    projected_pred = weights @ torch.tensor([1.0, 2.0, 4.0], dtype=torch.float32)
+    projected_true = weights @ torch.tensor([2.0, 4.0, 8.0], dtype=torch.float32)
+    expected = criterion(projected_pred, projected_true)
+
+    assert loss.item() == pytest.approx(expected.item())
+
+
+def test_weak_form_optimizer_phase_detaches_discrete_targets_for_trainable_encoder():
+    class _DiscreteEncoderWeakModel(torch.nn.Module):
+        CONT = False
+
+        def __init__(self):
+            super().__init__()
+            self.encoder_scale = torch.nn.Parameter(torch.tensor(2.0))
+            self.prediction_scale = torch.nn.Parameter(torch.tensor(0.5))
+
+        def encoder(self, runtime):
+            return self.encoder_scale * runtime.x
+
+        def dynamics(self, z, runtime):
+            return self.prediction_scale * z
+
+        def decoder(self, z, runtime):
+            return z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(
+            name="weak",
+            trainer="Weak",
+            config={"weak_form_params": {"N": 3, "dN": 1, "ordpol": 1, "ordint": 1}},
+        ),
+        config=config,
+        model_class=_DiscreteEncoderWeakModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _DiscreteEncoderWeakModel()
+    criterion = torch.nn.MSELoss()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[criterion, torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+    )
+    phase._customize_optimizer_artifact(
+        optimizer_state,
+        model,
+        PhaseContext(train_md={"dt_and_n_steps": [(1.0, 5)]}),
+        logging.getLogger("test.weak.discrete"),
+    )
+    series = RegularSeries(
+        time=torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0]),
+        state=torch.tensor([[1.0], [2.0], [4.0], [8.0], [16.0]]),
+        control=None,
+        meta={},
+    )
+    batch = RegularTrainerBatch.collate_series([series])
+
+    loss = phase._compute_losses(model, optimizer_state, batch, "dopri5", {})[0]
+    actual_grad = torch.autograd.grad(loss, model.encoder_scale)[0]
+
+    runtime = phases_module.batch_to_runtime(batch.to(phase.device))
+    latent = model.encoder(runtime)
+    projected_pred = model.dynamics(latent, runtime)[:, :-1, :].unfold(1, 3, 1) @ cast(
+        torch.Tensor, optimizer_state._weak_D
+    )
+    projected_target = latent[:, 1:, :].unfold(1, 3, 1) @ cast(
+        torch.Tensor, optimizer_state._weak_D
+    )
+    expected_loss = criterion(projected_pred, projected_target.detach())
+    expected_grad = torch.autograd.grad(expected_loss, model.encoder_scale)[0]
+
+    assert projected_target.requires_grad is True
+    assert actual_grad is not None
+    assert actual_grad.item() == pytest.approx(expected_grad.item())
+
+
+def test_weak_form_optimizer_phase_rejects_invalid_discrete_weight_normalization():
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+
+    with pytest.raises(
+        PhaseSpecValidationError,
+        match="weak_form_params.discrete_weight_normalization must be one of 'l2', 'l1', or 'none'",
+    ):
+        build_phase(
+            OptimizerPhaseSpec(
+                name="weak",
+                trainer="Weak",
+                config={
+                    "weak_form_params": {
+                        "N": 2,
+                        "dN": 1,
+                        "ordpol": 1,
+                        "ordint": 1,
+                        "discrete_weight_normalization": "bad",
+                    }
+                },
+            ),
+            config=config,
+            model_class=object,
+            dtype=torch.float32,
+            execution_services=execution_services,
+        )
+
+
+def test_weak_form_optimizer_phase_rejects_too_short_discrete_trajectories():
+    class _DiscreteWeakModel(torch.nn.Module):
+        CONT = False
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+        def encoder(self, runtime):
+            return runtime.x
+
+        def dynamics(self, z, runtime):
+            return self.weight * z
+
+        def decoder(self, z, runtime):
+            return z
+
+    config = {"model": {"name": "demo"}, "phases": []}
+    execution_services = ExecutionServices.from_config(config, default_device=torch.device("cpu"))
+    phase = build_phase(
+        OptimizerPhaseSpec(
+            name="weak",
+            trainer="Weak",
+            config={"weak_form_params": {"N": 3, "dN": 1, "ordpol": 1, "ordint": 1}},
+        ),
+        config=config,
+        model_class=_DiscreteWeakModel,
+        dtype=torch.float32,
+        execution_services=execution_services,
+    )
+    model = _DiscreteWeakModel()
+    optimizer_state = OptimizerStateArtifact(
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.1),
+        criteria=[torch.nn.MSELoss(), torch.nn.MSELoss()],
+        criteria_weights=[1.0],
+        criteria_names=["dynamics", "mse"],
+    )
+
+    with pytest.raises(
+        PhaseSpecValidationError,
+        match="Discrete Weak phase requires at least 4 time samples when weak_form_params.N=3 residual weights are requested",
+    ):
+        phase._customize_optimizer_artifact(
+            optimizer_state,
+            model,
+            PhaseContext(train_md={"dt_and_n_steps": [(1.0, 3)]}),
+            logging.getLogger("test.weak.discrete"),
+        )
 
 
 def test_select_best_cv_result_uses_goal_and_tie_breakers() -> None:


### PR DESCRIPTION
Closes #81

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 4.49s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 91.34s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-81/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 429 passed, 76 deselected, 29 warnings in 88.34s (0:01:28) ==========

stderr:

## Changed files
- src/dymad/agent/registry/training_schema.py
- src/dymad/numerics/__init__.py
- src/dymad/numerics/weak.py
- src/dymad/training/phases.py
- tests/test_agent_registry.py
- tests/test_assert_weak.py
- tests/test_contract_training_phase_runtime.py

## Agent notes
See diff for implementation details.
