### PR TITLE
Fix #87: Add a scripts guide to the getting started docs

### DIFF
--- a/docs/examples_and_scripts.rst
+++ b/docs/examples_and_scripts.rst
@@ -1,0 +1,60 @@
+Examples and Scripts
+====================
+
+DyMAD has two complementary example surfaces:
+
+- :doc:`examples` is the starting point. The notebooks are guided tutorials for learning the main
+  workflow and vocabulary.
+- ``scripts/`` is the broader runnable reference and demo library. It covers more topics than the
+  notebook gallery and is the next place to look when you want deeper coverage or a variant that
+  is not documented as a notebook.
+
+The notebook gallery is intentionally not a one-to-one mirror of ``scripts/``. Some topics have
+both notebooks and scripts, while others are currently available only as runnable scripts.
+
+Suggested progression
+---------------------
+
+1. Start with :doc:`examples` for a guided introduction.
+2. When you want to rerun an idea with different configs, look for the corresponding directory
+   under ``scripts/``.
+3. When you want a topic that is not covered in the notebooks, browse ``scripts/`` by system or
+   workflow area.
+
+Many script directories include ``*_cli.py`` entry points alongside the YAML configs and helper
+code needed to run the example.
+
+Where to look in ``scripts/``
+-----------------------------
+
+Use the current directory layout as a lightweight topic index:
+
+- Linear time-invariant and Koopman-style training:
+  ``scripts/linear_time_invariant/``, ``scripts/lti_1s/``, ``scripts/lti_dt/``,
+  ``scripts/lti_delay/``, ``scripts/lti_vlen/``, and ``scripts/2d_koopman/``.
+- Graph-structured dynamical systems:
+  ``scripts/linear_graph/``, ``scripts/linear_graph_auto/``, ``scripts/ltg_dt/``, and
+  ``scripts/ltg_dt_tv/``.
+- Kernel model workflows:
+  ``scripts/ker_s1/``, ``scripts/ker_s1u/``, ``scripts/ker_lti/``, and ``scripts/ker_lco/``.
+- Spectral analysis examples:
+  ``scripts/sa_2dk/``, ``scripts/sa_lco/``, and ``scripts/sa_lti/``.
+- Denoising, preprocessing, and post-processing:
+  ``scripts/denoise/`` and ``scripts/vortex/``.
+- Additional system-specific demos:
+  ``scripts/lorenz63/``, ``scripts/kuramoto/``, ``scripts/pirom_dyn/``,
+  ``scripts/pirom_res/``, and ``scripts/pirom_res_dt/``.
+
+If you started in a notebook topic such as 2D Koopman, linear graphs, denoising, SA-LCO, or
+vortex, checking the similarly named directory under ``scripts/`` is usually the fastest way to
+find more runnable variants. For example:
+
+- the 2D Koopman notebooks lead naturally into ``scripts/2d_koopman/`` for training and sweep
+  runs
+- the linear graph notebooks lead naturally into ``scripts/linear_graph/`` and the related
+  ``scripts/ltg_dt/`` families
+- the denoising notebook points toward ``scripts/denoise/`` for the training and preprocessing
+  steps
+
+When you are not sure where to start, open the notebook gallery first and then use the closest
+matching directory under ``scripts/`` as the broader reference surface.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -3,9 +3,14 @@ Getting Started
 
 After cloning our `GitHub repository <https://github.com/apus-lab/dymad>`_
 
+The recommended path for a new user is to start with the notebook tutorials and then continue into
+the runnable script library when you want broader coverage.
+
 You can
 
-- Check the hands-on :doc:`Examples <examples>` - more are coming!  (e.g., we are cleaning up those in `dymad/examples`)
+- Start with the hands-on :doc:`Examples <examples>` notebook gallery.
+- Continue with :doc:`Examples and Scripts <examples_and_scripts>` to see how the notebook
+  tutorials relate to the broader ``scripts/`` library and where to look next by topic.
 - Read the developer-facing :doc:`Architecture <architecture>` map if you need the current MCP,
   checkpoint, and package layering.
 - Use the :doc:`Feature Placement <feature-placement>` guide to decide where new features belong.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Explore More
    :maxdepth: 2
 
    getting_started
+   examples_and_scripts
    architecture
    feature-placement
    algorithm-integration-guide


### PR DESCRIPTION
Closes #87

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 5.52s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 107.86s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-87/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========= 428 passed, 76 deselected, 29 warnings in 104.18s (0:01:44) ==========

stderr:

## Changed files
- docs/getting_started.rst
- docs/index.rst
- docs/examples_and_scripts.rst

## Agent notes
See diff for implementation details.
