### PR TITLE
Fix #87: Add a scripts guide to the getting started docs

### DIFF
--- a/docs/examples_and_scripts.rst
+++ b/docs/examples_and_scripts.rst
@@ -1,0 +1,64 @@
+Examples and Scripts
+====================
+
+DyMAD has two complementary learning surfaces:
+
+- ``examples/`` is the starting point. The published :doc:`Examples <examples>` page is a notebook
+  gallery for learning the main ideas step by step.
+- ``scripts/`` is the broader runnable library. It contains more workflows, variants, utilities,
+  and topic coverage than the notebook gallery.
+
+Use them as a progression rather than expecting a strict mirror. The notebooks are introductory
+tutorials, while the scripts are the place to look when you want more depth, more model variants,
+or a runnable reference for a specific feature. Not every script has a matching notebook, and this
+documentation does not assume a one-to-one mapping.
+
+How to move from notebooks to scripts
+-------------------------------------
+
+Start with the notebook gallery when you want a guided walkthrough of the core DyMAD workflow.
+Then move into ``scripts/`` when you want to:
+
+- rerun a workflow from Python or the command line
+- inspect the YAML configuration used for a model or dataset
+- explore model families or analysis workflows that are not covered in the notebooks
+- adapt an existing example to your own system
+
+In many script folders, ``*_cli.py`` files are the most direct command-line entry points, nearby
+``.py`` files show the underlying runnable example, and neighboring ``.yaml`` files provide the
+configs those runs use.
+
+Where to look in ``scripts/``
+-----------------------------
+
+The current script tree is broad, so it is easiest to navigate by topic:
+
+- Introductory training workflows similar to the notebook material:
+  ``scripts/linear_time_invariant/``, ``scripts/linear_graph/``, ``scripts/2d_koopman/``
+- Kernel-based examples:
+  ``scripts/ker_lti/``, ``scripts/ker_s1/``, ``scripts/ker_s1u/``, ``scripts/ker_lco/``
+- Discrete-time, delayed, or variant system setups:
+  ``scripts/lti_dt/``, ``scripts/ltg_dt/``, ``scripts/ltg_dt_tv/``, ``scripts/lti_delay/``,
+  ``scripts/lti_1s/``, ``scripts/lti_vlen/``
+- Reduced-order and PIROM workflows:
+  ``scripts/pirom_dyn/``, ``scripts/pirom_res/``, ``scripts/pirom_res_dt/``
+- Spectral-analysis-oriented examples:
+  ``scripts/sa_lti/``, ``scripts/sa_lco/``, ``scripts/sa_2dk/``
+- Data preparation, denoising, and post-processing utilities:
+  ``scripts/denoise/``, ``scripts/kuramoto/``, ``scripts/vortex/``
+
+If you began with a specific notebook topic, these are good next stops:
+
+- After the linear and Koopman notebooks, compare the broader training and sweep examples under
+  ``scripts/linear_time_invariant/``, ``scripts/linear_graph/``, and ``scripts/2d_koopman/``.
+- After the spectral analysis notebooks, explore ``scripts/sa_lti/``, ``scripts/sa_lco/``, and
+  ``scripts/sa_2dk/`` for additional analysis-oriented runs.
+- After the vortex notebooks, look at ``scripts/vortex/vor_train_cli.py``,
+  ``scripts/vortex/vor_proc_cli.py``, and ``scripts/vortex/vor_post.py`` for the surrounding
+  training and processing workflow.
+
+What this guide does not require
+--------------------------------
+
+You do not need a matching notebook for every runnable script. The intended structure is a curated
+set of notebook tutorials in ``examples/`` plus a larger reference/demo surface in ``scripts/``.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -5,7 +5,9 @@ After cloning our `GitHub repository <https://github.com/apus-lab/dymad>`_
 
 You can
 
-- Check the hands-on :doc:`Examples <examples>` - more are coming!  (e.g., we are cleaning up those in `dymad/examples`)
+- Start with the hands-on notebook tutorials in :doc:`Examples <examples>`.
+- Continue with :doc:`Examples and Scripts <examples_and_scripts>` when you want broader runnable
+  coverage than the notebook gallery provides.
 - Read the developer-facing :doc:`Architecture <architecture>` map if you need the current MCP,
   checkpoint, and package layering.
 - Use the :doc:`Feature Placement <feature-placement>` guide to decide where new features belong.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,5 +48,6 @@ Explore More
    example-script-pattern
    roadmap
    examples
+   examples_and_scripts
    theory
    api_ref


### PR DESCRIPTION
Closes #87

## Summary
This PR was generated by A-Dev.

## Verification
PASS make check
exit code: 0
duration: 5.68s
stdout:
ruff check .
All checks passed!
ruff format . --check
270 files already formatted
pyright --pythonpath "####/miniconda3/bin/python"
0 errors, 0 warnings, 0 informations

stderr:


PASS pytest -m "not slow and not extra_slow"
exit code: 0
duration: 111.54s
stdout:
t.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
tests/test_assert_krr.py::test_krr
  ####/miniconda3/lib/python3.12/site-packages/torch/_tensor.py:1120: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return self.reciprocal() * other

tests/test_workflow_sa_lti.py::test_sa[1]
  ####/Repos/dymad-dev/.a-dev/worktrees/issue-87/src/dymad/training/ls_update.py:368: UserWarning: Casting complex values to real discards the imaginary part (Triggered internally at ####/work/pytorch/pytorch/pytorch/aten/src/ATen/native/Copy.cpp:308.)
    Wt = torch.tensor(W, dtype=dtype, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========= 428 passed, 76 deselected, 29 warnings in 107.38s (0:01:47) ==========

stderr:

## Changed files
- docs/getting_started.rst
- docs/index.rst
- docs/examples_and_scripts.rst

## Agent notes
See diff for implementation details.
